### PR TITLE
The unspecified dependency on 'kaminari'

### DIFF
--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'kaminari'
   spec.add_development_dependency 'activerecord', '>= 3.2'
   spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'elasticsearch-extensions'
   spec.add_development_dependency 'rubysl', '~> 2.0' if RUBY_ENGINE == 'rbx'
 
+  spec.add_dependency 'kaminari'
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'elasticsearch'
 end


### PR DESCRIPTION
I got `cannot load such file -- kaminari` when added 'chewy' to `Gemfile`

You specified 'kaminari' as development dependency, but it has been used as runtime dependency.

https://github.com/toptal/chewy/blob/master/lib/chewy/query/pagination.rb#L1
