### PR TITLE
Fix bug in compose method

### DIFF
--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -19,7 +19,7 @@ module Chewy
           object.send(name)
         end
 
-        result = if result.is_a?(Enumerable)
+        result = if result.is_a?(Enumerable) && !result.is_a?(Hash)
           result.map { |object| nested_compose(object) }
         else
           nested_compose(result)

--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -39,6 +39,18 @@ describe Chewy::Fields::Base do
 
       specify { field.compose(double(name: 'Alex')).should == {name: 'Alex'} }
     end
+
+    context do
+      let(:field) { described_class.new(:name, type: 'object') }
+      let(:object) { double(name: { key1: 'value1', key2: 'value2' }) }
+
+      before do
+        field.nested(described_class.new(:key1, value: ->(h){ h[:key1] }))
+        field.nested(described_class.new(:key2, value: ->(h){ h[:key2] }))
+      end
+
+      specify{ field.compose(object).should == { name: { 'key1' => 'value1', 'key2' => 'value2' } } }
+    end
   end
 
   describe '#nested' do


### PR DESCRIPTION
When we define field with `object` type and nested fields, like that:

``` ruby
      field :name, type: 'object', boost: 10, value: ->(){ name_translations } do
        field :ru, value: ->(name){ name['ru'] }
        field :en, value: ->(name){ name['en'] }
      end
```

We get the error during indexation, because method `compose` converts any `Hash` to `Array` by using method `map`:

``` ruby
        result = if result.is_a?(Enumerable)
          result.map { |object| nested_compose(object) }
        else
          nested_compose(result)
        end if nested.any? && !multi_field?
```

`Hash` is `Enumerable`. Iterating through `Hash` converts it to `Array`
