### PR TITLE
Support 'nested' type

### DIFF
--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -13,7 +13,7 @@ module Chewy
       end
 
       def object_field?
-        (nested.any? && options[:type].blank?) || options[:type].to_s == 'object'
+        (nested.any? && options[:type].blank?) || ['object', 'nested'].include?(options[:type].to_s)
       end
 
       def root_field?


### PR DESCRIPTION
Adds support for Elasticsearch's nested mapping type. See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-nested-type.html

In the current versie Chewy doesn't work well with configuration for fields, which parent field is mapped as type: 'nested'. E.g. all defined fields will get the default type 'string', even if a type is specified in the index. The parent is incorrectly interpreted with the 'multi_field' semantics.

This pull request fixes this behavior.
