### PR TITLE
eager_load_chewy! conflicts with rails autoloading

### DIFF
--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -14,7 +14,7 @@ end
 
 def eager_load_chewy!
   Rails.application.config.paths['app/chewy'].existent.each do |dir|
-    Dir.glob(File.join(dir, '**/*.rb')).each { |file| require file }
+    Dir.glob(File.join(dir, '**/*.rb')).each { |file| require_dependency file }
   end
 end
 


### PR DESCRIPTION
Bit of a weird one this, perhaps I'm doing something I shouldn't....

I've added a `concerns` directory to `/app/chewy` because I have some duplication across index definitions.  I then include these modules into the index definitions, e.g.:

``` ruby
class AccountsIndex < Chewy::Index
  define_type AccountX.includes(:associationX) do
    include CommonIndexStuff

    field :fieldX
  end

  define_type AccountY.includes(:associationY) do
    include CommonIndexStuff

    field :fieldY
  end
end
```

When I run `rake chewy:reset`, I get `ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern` because the `eager_load_chewy!` method in `chewy.rake` first causes Rails to autoload the `CommonIndexStuff` module, and then explicitly `require`s it again. 

There are three ways to solve this:
1. Only eager load index definition files, using the convention that all index definitions are in files that end with the suffix `_index.rb`.
2. Use `require_dependency` rather than `require` in `eager_load_chewy!`, because that lets Rails autoloading mechanism ignore the second attempt to load that file.
3. Move all non-index definition files out of `/app/chewy` and into another directory like `/lib/chewy`.

I don't like option 3, because that just seems cryptic and annoying. Out of options 1 and 2, I've plumped for 1 because 2 felt like unnecessary coupling to Rails.

Thoughts?
