### PR TITLE
don't assume activerecord ids are integers

### DIFF
--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -104,7 +104,7 @@ module Chewy
         attr_reader :model, :scope, :options
 
         def import_ids(ids, import_options = {}, &block)
-          ids = ids.map(&:to_i).uniq
+          ids.uniq!
 
           indexed = true
           merged_scope(scoped_model(ids)).find_in_batches(import_options.slice(:batch_size)) do |objects|


### PR DESCRIPTION
Hey. So I had a bunch of errors appear when I started trying to `update_index` that was backed by an ActiveRecord model with a uuid primary key. It turns out the `Chewy::Type::Adapter::ActiveRecord` class is forcing all ids to be integers before it imports them. I've taken that out, and all the specs continue to pass. Also, my indexing works again.

What was the reason for this `to_i`?
