### PR TITLE
Handle must_not query/filter mode with a single filter condition

### DIFF
--- a/lib/chewy/query/compose.rb
+++ b/lib/chewy/query/compose.rb
@@ -30,7 +30,7 @@ module Chewy
       def _queries_join queries, logic
         queries = queries.compact
 
-        if queries.many?
+        if queries.many? || (queries.any? && logic == :must_not)
           case logic
           when :dis_max
             { dis_max: { queries: queries } }
@@ -51,7 +51,7 @@ module Chewy
       def _filters_join filters, logic
         filters = filters.compact
 
-        if filters.many?
+        if filters.many? || (filters.any? && logic == :must_not)
           case logic
           when :and, :or
             { logic => filters }

--- a/spec/chewy/query/criteria_spec.rb
+++ b/spec/chewy/query/criteria_spec.rb
@@ -376,6 +376,10 @@ describe Chewy::Query::Criteria do
     specify { _queries_join([query], :should).should == query }
     specify { _queries_join([query, query], :should).should == {bool: {should: [query, query]}} }
 
+    specify { _queries_join([], :must_not).should be_nil }
+    specify { _queries_join([query], :must_not).should == {bool: {must_not: [query]}} }
+    specify { _queries_join([query, query], :must_not).should == {bool: {must_not: [query, query]}} }
+
     specify { _queries_join([], '25%').should be_nil }
     specify { _queries_join([query], '25%').should == query }
     specify { _queries_join([query, query], '25%').should == {bool: {should: [query, query], minimum_should_match: '25%'}} }
@@ -403,6 +407,10 @@ describe Chewy::Query::Criteria do
     specify { _filters_join([], :should).should be_nil }
     specify { _filters_join([filter], :should).should == filter }
     specify { _filters_join([filter, filter], :should).should == {bool: {should: [filter, filter]}} }
+
+    specify { _filters_join([], :must_not).should be_nil }
+    specify { _filters_join([filter], :must_not).should == {bool: {must_not: [filter]}} }
+    specify { _filters_join([filter, filter], :must_not).should == {bool: {must_not: [filter, filter]}} }
 
     specify { _filters_join([], '25%').should be_nil }
     specify { _filters_join([filter], '25%').should == filter }


### PR DESCRIPTION
#75 introduced a bug in the case of a single filter condition with the :must_not query/filter mode
