### PR TITLE
Link gem's homepage to GH

### DIFF
--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['kinwizard@gmail.com']
   spec.summary       = %q{Elasticsearch ODM client wrapper}
   spec.description   = %q{Chewy provides functionality for Elasticsearch index handling, documents import mappings and chainable query DSL}
-  spec.homepage      = ''
+  spec.homepage      = 'https://github.com/toptal/chewy'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Reading on chewy from [Rubygems](http://rubygems.org/gems/chewy), I needed to do a google search on the gem's GH page to get here.

Adding this link will save a few productive seconds :joy:.
