### PR TITLE
eager load should find indexes inside engines too

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -30,7 +30,8 @@ module Chewy
     end
 
     console do |app|
-      Chewy.logger = ActiveRecord::Base.logger
+      Chewy.logger = ActiveRecord::Base.logger if defined?(ActiveRecord)
+
       if app.sandbox?
         Chewy.strategy(:bypass)
       else

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -1,5 +1,9 @@
 module Chewy
   class Railtie < Rails::Railtie
+    def self.all_engines
+      Rails::Engine.subclasses.map(&:instance) + [Rails.application]
+    end
+
     class RequestStrategy
       def initialize(app)
         @app = app
@@ -54,7 +58,9 @@ module Chewy
     end
 
     initializer 'chewy.add_app_chewy_path' do |app|
-      app.config.paths.add 'app/chewy'
+      Chewy::Railtie.all_engines.each do |engine|
+        engine.paths.add 'app/chewy'
+      end
     end
   end
 end

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -13,8 +13,12 @@ def subscribe_task_stats!
 end
 
 def eager_load_chewy!
-  Rails.application.config.paths['app/chewy'].existent.each do |dir|
-    Dir.glob(File.join(dir, '**/*.rb')).each { |file| require_dependency file }
+  dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths['app/chewy'].existent }.flatten.uniq
+
+  dirs.each do |dir|
+    Dir.glob(File.join(dir, '**/*.rb')).each do |file|
+      require_dependency file
+    end
   end
 end
 


### PR DESCRIPTION
I'm sure this used to work, but maybe I'm misremembering. If you have a rails app that includes engines and those engines define chewy indexes, they are not found by the rake task when you do ```rake chewy:update:all```. 

What is the reasoning for using this:

```ruby
Rails.application.config.paths['app/chewy'].existent
```

and then globbing further?