### PR TITLE
Allow scrip_score to receive params

### DIFF
--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -348,21 +348,25 @@ module Chewy
     # added to the search request and combinded according to
     # <tt>boost_mode</tt> and <tt>score_mode</tt>
     #
-    #   UsersIndex.script_score("doc['boost'].value", filter: { term: {foo: :bar} })
+    #   UsersIndex.script_score("doc['boost'].value", params: { modifier: 2 }, filter: { term: {foo: :bar} })
     #       # => {body:
     #              query: {
     #                function_score: {
     #                  query: { ...},
     #                  functions: [{
     #                    script_score: {
-    #                       script: "doc['boost'].value"
+    #                       script: "doc['boost'].value * modifier",
+    #                       params: { modifier: 2 }
     #                     },
     #                     filter: { term: { foo: :bar } }
     #                    }
     #                  }]
     #                } } }
     def script_score(script, options = {})
-      scoring = options.merge(script_score: { script: script })
+      script_score = { script: script }
+      script_score[:params] = options.delete(:params) if options.key?(:params)
+
+      scoring = options.merge(script_score: script_score)
       chain { criteria.update_scores scoring }
     end
 

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -348,7 +348,7 @@ module Chewy
     # added to the search request and combinded according to
     # <tt>boost_mode</tt> and <tt>score_mode</tt>
     #
-    #   UsersIndex.script_score("doc['boost'].value", params: { modifier: 2 }, filter: { term: {foo: :bar} })
+    #   UsersIndex.script_score("doc['boost'].value", params: { modifier: 2 })
     #       # => {body:
     #              query: {
     #                function_score: {
@@ -357,16 +357,12 @@ module Chewy
     #                    script_score: {
     #                       script: "doc['boost'].value * modifier",
     #                       params: { modifier: 2 }
-    #                     },
-    #                     filter: { term: { foo: :bar } }
+    #                     }
     #                    }
     #                  }]
     #                } } }
     def script_score(script, options = {})
-      script_score = { script: script }
-      script_score[:params] = options.delete(:params) if options.key?(:params)
-
-      scoring = options.merge(script_score: script_score)
+      scoring = { script_score: { script: script }.merge(options) }
       chain { criteria.update_scores scoring }
     end
 

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -107,6 +107,7 @@ describe Chewy::Query do
     specify { expect(subject.script_score('23').criteria.scores).to eq([ { script_score: { script: '23' } } ]) }
     specify { expect { subject.script_score('23') }.not_to change { subject.criteria.scores } }
     specify { expect(subject.script_score('23', filter: { foo: :bar}).criteria.scores).to eq([{ script_score: { script: '23' }, filter: { foo: :bar } }]) }
+    specify { expect(subject.script_score('23 * factor', params: { factor: 0.5}).criteria.scores).to eq([{ script_score: { script: '23 * factor', params: { factor: 0.5} } }]) }
   end
 
   describe '#boost_factor' do

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -106,7 +106,6 @@ describe Chewy::Query do
     specify { expect(subject.script_score('23')).not_to eq(subject) }
     specify { expect(subject.script_score('23').criteria.scores).to eq([ { script_score: { script: '23' } } ]) }
     specify { expect { subject.script_score('23') }.not_to change { subject.criteria.scores } }
-    specify { expect(subject.script_score('23', filter: { foo: :bar}).criteria.scores).to eq([{ script_score: { script: '23' }, filter: { foo: :bar } }]) }
     specify { expect(subject.script_score('23 * factor', params: { factor: 0.5}).criteria.scores).to eq([{ script_score: { script: '23 * factor', params: { factor: 0.5} } }]) }
   end
 


### PR DESCRIPTION
By passing params scripts can now be cached even when we want to pass values to them.

Unfortunately I have a very limited grasp on both ElasticSearch and Chewy so please advise if this is the wrong way to go about it or if this is already implemented somewhere (I couldn't find it).