### PR TITLE
Add failing test case for urgent strategy and default scope

### DIFF
--- a/lib/chewy/strategy/urgent.rb
+++ b/lib/chewy/strategy/urgent.rb
@@ -10,7 +10,12 @@ module Chewy
     #
     class Urgent < Base
       def update type, objects, options = {}
-        type.import(objects)
+        objects = Array(objects)
+        if objects.all? { |object| object.respond_to?(:id) }
+          type.import(objects.map(&:id))
+        else
+          type.import(objects)
+        end
       end
     end
   end

--- a/lib/chewy/strategy/urgent.rb
+++ b/lib/chewy/strategy/urgent.rb
@@ -10,7 +10,7 @@ module Chewy
     #
     class Urgent < Base
       def update type, objects, options = {}
-        objects = Array(objects)
+        objects = Array.wrap(objects)
         if objects.all? { |object| object.respond_to?(:id) }
           type.import(objects.map(&:id))
         else

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -75,7 +75,7 @@ describe Chewy::Strategy do
       end
     end
 
-    context "urgent strategy when type has a default scope" do
+    context "urgent strategy when type has a default scope", :active_record do
       around { |example| Chewy.strategy(:bypass) { example.run } }
 
       before do


### PR DESCRIPTION
This is an "interesting" regression I noticed since the work refactoring the strategies.

We have different behavior between urgent and atomic strategy: atomic strategy passes id backrefs, while urgent strategy passes the objects themselves.

This ends up causing the atomic strategy updates to respect the default activerecord scope, while the urgent strategy updates do not: https://github.com/toptal/chewy/blob/0c726fb79912817e662ac432ead978ad33fce88a/lib/chewy/type/adapter/active_record.rb#L74-L80 .

The easiest fix might be only using id backrefs in this case in ActiveRecord#import, but the existing test suite supports indexing records for which id is nil, so I cannot make this fix on my own since it will invalidate many existing tests.

Also it occurred to me to repeat the default scope logic when passing the backref in the model observing block, but this doesn't work: in this block we can only decide whether or not to update the index for the backref, not whether to reindex or delete. So if a record goes from in scope to out of scope, we must be observing it in order to fulfill the necessary deletion.

So finally I am left with the fix I propose in this PR, modifying the urgent strategy. It's not a very satisfying fix since it doesn't address the root of the problem. But perhaps it's better than the current inconsistency between strategies.