### PR TITLE
[Fix doc] s/types_hash/type_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ You are able to access index-defined types with the following API:
 
 ```ruby
 UsersIndex::User # => UsersIndex::User
-UsersIndex.types_hash['user'] # => UsersIndex::User
+UsersIndex.type_hash['user'] # => UsersIndex::User
 UsersIndex.user # => UsersIndex::User
 UsersIndex.types # => [UsersIndex::User]
 UsersIndex.type_names # => ['user']


### PR DESCRIPTION
UsersIndex.types_hash
NoMethodError: undefined method `types_hash' for UsersIndex