### PR TITLE
Replace `gsub(/blah\Z/, )` with `sub(/blah\Z/, )`

### DIFF
--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -34,7 +34,7 @@ module Chewy
       else
         @index_name ||= begin
           build_index_name(
-            name.gsub(/Index\Z/, '').demodulize.underscore,
+            name.sub(/Index\Z/, '').demodulize.underscore,
             prefix: Chewy.configuration[:prefix]
           ) if name
         end


### PR DESCRIPTION
The regex in this particular case is guaranteed to occur maximum once in any input string, so it is safe to use `sub` instead of `gsub` there. Although it probably doesn't matter here, `sub` is also a bit faster than `gsub`.

```ruby
require 'benchmark/ips'

Benchmark.ips do |ips|
  ips.report('gsub') { 'UserIndex'.gsub(/Index\Z/, '') }
  ips.report( 'sub') { 'UserIndex'. sub(/Index\Z/, '') }
end

__END__

Calculating -------------------------------------
                gsub    20.930k i/100ms
                 sub    39.750k i/100ms
-------------------------------------------------
                gsub    333.065k (± 3.6%) i/s -      1.674M
                 sub    971.413k (±12.5%) i/s -      4.691M
```