### PR TITLE
Simplify array_difference helper method

### DIFF
--- a/lib/chewy/rspec/update_index.rb
+++ b/lib/chewy/rspec/update_index.rb
@@ -212,7 +212,7 @@ RSpec::Matchers.define :update_index do |type_name, options = {}|
   def compare_attributes expected, real
     expected.inject(true) do |result, (key, value)|
       equal = if value.is_a?(Array) && real[key].is_a?(Array)
-        array_difference(value, real[key]) && array_difference(real[key], value)
+        value.sort == real[key].sort
       elsif value.is_a?(Hash) && real[key].is_a?(Hash)
         compare_attributes(value, real[key])
       else
@@ -220,15 +220,5 @@ RSpec::Matchers.define :update_index do |type_name, options = {}|
       end
       result && equal
     end
-  end
-
-  def array_difference first, second
-    difference = first.to_ary.dup
-    second.to_ary.each do |element|
-      if index = difference.index(element)
-        difference.delete_at(index)
-      end
-    end
-    difference.none?
   end
 end


### PR DESCRIPTION
We don't need to use fancy loops in order to
figure out whether arrays contain the same elements.

Let's just sort and compare.

This is not only more readable, but also faster:

```ruby
require 'benchmark/ips'

def array_difference first, second
  difference = first.to_ary.dup
  second.to_ary.each do |element|
    if index = difference.index(element)
      difference.delete_at(index)
    end
  end
  difference.none?
end

first = %w[one one two]
second = %w[one two one]

Benchmark.ips do |x|
  x.report('java') { array_difference(first, second) && array_difference(second, first) }
  x.report('ruby') { first.sort == second.sort }
end

__END__

Calculating -------------------------------------
                java    15.874k i/100ms
                ruby    23.175k i/100ms
-------------------------------------------------
                java    214.599k (± 8.1%) i/s -      1.095M
                ruby    501.706k (±10.2%) i/s -      2.433M

```