### PR TITLE
Fix cities ordering to prevent random test failing

### DIFF
--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -319,7 +319,11 @@ describe Chewy::Fields::Base do
         City.belongs_to :country
 
         if active_record?
-          Country.has_many :cities, -> { order(:id) }
+          if ActiveRecord::VERSION::MAJOR >= 4
+            Country.has_many :cities, -> { order :id }
+          else
+            Country.has_many :cities, order: :id
+          end
         else # mongoid
           Country.has_many :cities, order: :id.asc
         end

--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -317,7 +317,12 @@ describe Chewy::Fields::Base do
         stub_model(:country)
 
         City.belongs_to :country
-        Country.has_many :cities, -> { order(:id) }
+
+        if active_record?
+          Country.has_many :cities, -> { order(:id) }
+        else # mongoid
+          Country.has_many :cities, order: :id.asc
+        end
 
         stub_index(:countries) do
           define_type Country do

--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -317,7 +317,7 @@ describe Chewy::Fields::Base do
         stub_model(:country)
 
         City.belongs_to :country
-        Country.has_many :cities
+        Country.has_many :cities, -> { order(:id) }
 
         stub_index(:countries) do
           define_type Country do

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -59,7 +59,7 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
       let!(:deleted) { 4.times.map { |i| City.create!.tap(&:destroy) }.sort_by(&:id) }
       subject { described_class.new(City) }
 
-      specify { expect(import.first[:index]).to match_array(cities) }
+      specify { expect(import).to eq([{index: cities}]) }
       specify { expect(import nil).to eq([]) }
 
       specify { expect(import(City.order(:id.asc))).to eq([{index: cities}]) }

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -48,11 +48,6 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
   end
 
   describe '#import' do
-    before do
-      City.class_eval do
-        City.default_scope -> { order(:id.asc) }
-      end
-    end
     def import(*args)
       result = []
       subject.import(*args) { |data| result.push data }

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -48,6 +48,11 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
   end
 
   describe '#import' do
+    before do
+      City.class_eval do
+        City.default_scope -> { order(:id.asc) }
+      end
+    end
     def import(*args)
       result = []
       subject.import(*args) { |data| result.push data }

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -145,8 +145,8 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
     end
 
     context 'default scope' do
-      let!(:cities) { 4.times.map { |i| City.create!(rating: i/3) }.sort_by(&:id) }
-      let!(:deleted) { 3.times.map { |i| City.create!.tap(&:destroy) }.sort_by(&:id) }
+      let!(:cities) { 4.times.map { |i| City.create!(id: i, rating: i/3) }.sort_by(&:id) }
+      let!(:deleted) { 3.times.map { |i| City.create!(id: 4 + i).tap(&:destroy) }.sort_by(&:id) }
       subject { described_class.new(City.where(rating: 0)) }
 
       specify { expect(import).to eq([{index: cities.first(3)}]) }
@@ -242,8 +242,8 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
 
   describe '#load' do
     context do
-      let!(:cities) { 3.times.map { |i| City.create!(rating: i/2) }.sort_by(&:id) }
-      let!(:deleted) { 2.times.map { |i| City.create!.tap(&:destroy) }.sort_by(&:id) }
+      let!(:cities) { 3.times.map { |i| City.create!(id: i, rating: i/2) }.sort_by(&:id) }
+      let!(:deleted) { 2.times.map { |i| City.create!(id: 3 + i).tap(&:destroy) }.sort_by(&:id) }
 
       let(:type) { double(type_name: 'user') }
 

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -59,7 +59,7 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
       let!(:deleted) { 4.times.map { |i| City.create!.tap(&:destroy) }.sort_by(&:id) }
       subject { described_class.new(City) }
 
-      specify { expect(import).to eq([{index: cities}]) }
+      specify { expect(import.first[:index]).to match_array(cities) }
       specify { expect(import nil).to eq([]) }
 
       specify { expect(import(City.order(:id.asc))).to eq([{index: cities}]) }

--- a/spec/chewy/type/adapter/mongoid_spec.rb
+++ b/spec/chewy/type/adapter/mongoid_spec.rb
@@ -59,7 +59,7 @@ describe Chewy::Type::Adapter::Mongoid, :mongoid do
       let!(:deleted) { 4.times.map { |i| City.create!.tap(&:destroy) }.sort_by(&:id) }
       subject { described_class.new(City) }
 
-      specify { expect(import).to eq([{index: cities}]) }
+      specify { expect(import).to match([{index: match_array(cities)}]) }
       specify { expect(import nil).to eq([]) }
 
       specify { expect(import(City.order(:id.asc))).to eq([{index: cities}]) }


### PR DESCRIPTION
I added ordering by `:id` scope to `has_many :cities` association to prevent random test behavior.
It think, it reproduces randomly. This ones failed:

 * https://travis-ci.org/toptal/chewy/jobs/55774252
 * https://travis-ci.org/toptal/chewy/jobs/55774278

But other ones from https://travis-ci.org/toptal/chewy/builds/55774229 are not.

The reason is:

    expected: {:country=>{"id"=>1, "cities"=>[{"id"=>1, "name"=>"City1"}, {"id"=>2, "name"=>"City2"}]}}
    got: {:country=>{"id"=>1, "cities"=>[{"id"=>2, "name"=>"City2"}, {"id"=>1, "name"=>"City1"}]}}

It's just improper ordering.

I turned on SQL logging on specs and figured out this:

    % rspec spec/chewy/fields/base_spec.rb:333

    ...
    D, [2015-03-25T13:47:07.055722 #21393] DEBUG -- :    (0.0ms)  begin transaction
    D, [2015-03-25T13:47:07.058849 #21393] DEBUG -- :   SQL (0.2ms)  INSERT INTO "cities" ("id", "name") VALUES (?, ?)  [["id", 1], ["name", "City1"]]
    D, [2015-03-25T13:47:07.059113 #21393] DEBUG -- :    (0.0ms)  commit transaction
    D, [2015-03-25T13:47:07.059371 #21393] DEBUG -- :    (0.0ms)  begin transaction
    D, [2015-03-25T13:47:07.059764 #21393] DEBUG -- :   SQL (0.0ms)  INSERT INTO "cities" ("id", "name") VALUES (?, ?)  [["id", 2], ["name", "City2"]]
    D, [2015-03-25T13:47:07.059938 #21393] DEBUG -- :    (0.0ms)  commit transaction
    D, [2015-03-25T13:47:07.071737 #21393] DEBUG -- :   City Load (0.1ms)  SELECT "cities".* FROM "cities" WHERE "cities"."country_id" = ?  [["country_id", 1]]

The last `SELECT` should use `ORDER BY` because without it the ordering is not guaranteed.

After adding `-> { order(:id) }`:

    D, [2015-03-25T13:48:41.249376 #21406] DEBUG -- :   City Load (0.1ms)  SELECT "cities".* FROM "cities" WHERE "cities"."country_id" = ?  ORDER BY "cities"."id" ASC  [["country_id", 1]]

And it excludes this undefined behavior.