### PR TITLE
Update README with a section about the scope inside of define_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ See [config.rb](lib/chewy/config.rb) for more details.
   end
   ```
 
+### Inside the scope of .define_type
+
+You can access the class that the defined type is mapped to using:
+
+```ruby
+adapter.target
+```
+
 ### Types access
 
 You are able to access index-defined types with the following API:


### PR DESCRIPTION
Related to issue #164 it seemed prudent to create a section of the README that outlines important aspects of the scope inside of a block that is passed to define_type.