### PR TITLE
Add note to README about rspec and transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,14 @@ rake chewy:update[users] # updates UsersIndex
 Just add `require 'chewy/rspec'` to your spec_helper.rb and you will get additional features:
 See [update_index.rb](lib/chewy/rspec/update_index.rb) for more details.
 
+Note that Chewy depends on transactions so if using say Database Cleaner with transaction strategy, switch to truncation for the suite with:
+
+```ruby
+  before(:all) do
+    DatabaseCleaner.strategy = :truncation
+  end
+```
+
 ## TODO a.k.a coming soon:
 
 * Typecasting support


### PR DESCRIPTION
We recently ran into an issue with testing when we started using Database Cleaner and it took a little while to track down: testing for `update_index` to have happened when using an rspec wrapper that makes uses of transactions will fail. Instead, one needs to use truncation or some other method around the suite that is testing the index updates.