### PR TITLE
.import(nil) should be treated as equivalent to .import()

### DIFF
--- a/lib/chewy/type/adapter/orm.rb
+++ b/lib/chewy/type/adapter/orm.rb
@@ -77,7 +77,7 @@ module Chewy
           import_options = args.extract_options!
           batch_size = import_options[:batch_size] || BATCH_SIZE
 
-          collection = args.empty? ? default_scope :
+          collection = import_all?(args) ? default_scope :
             (args.one? && args.first.is_a?(relation_class) ? args.first : args.flatten.compact)
 
           if collection.is_a?(relation_class)
@@ -135,6 +135,10 @@ module Chewy
 
         def all_scope_where_ids_in(ids)
           scope_where_ids_in(all_scope, ids)
+        end
+
+        def import_all?(args)
+          args.empty? || args == [nil]
         end
       end
     end

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -8,6 +8,7 @@ module Chewy
         # Returns true or false depending on success.
         #
         #   UsersIndex::User.import                          # imports default data set
+        #   UsersIndex::User.import nil                      # imports default data set
         #   UsersIndex::User.import User.active              # imports active users
         #   UsersIndex::User.import [1, 2, 3]                # imports users with specified ids
         #   UsersIndex::User.import users                    # imports users collection
@@ -42,6 +43,7 @@ module Chewy
         # Raises Chewy::ImportFailed exception in case of import errors.
         #
         #   UsersIndex::User.import!                          # imports default data set
+        #   UsersIndex::User.import! nil                      # imports default data set
         #   UsersIndex::User.import! User.active              # imports active users
         #   UsersIndex::User.import! [1, 2, 3]                # imports users with specified ids
         #   UsersIndex::User.import! users                    # imports users collection

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -20,12 +20,14 @@ describe Chewy::Type::Import do
 
   describe '.import', :orm do
     specify { expect(city.import).to eq(true) }
+    specify { expect(city.import nil).to eq(true) }
     specify { expect(city.import([])).to eq(true) }
     specify { expect(city.import(dummy_cities)).to eq(true) }
     specify { expect(city.import(dummy_cities.map(&:id))).to eq(true) }
 
     specify { expect { city.import([]) }.not_to update_index(city) }
     specify { expect { city.import }.to update_index(city).and_reindex(dummy_cities) }
+    specify { expect { city.import nil }.to update_index(city).and_reindex(dummy_cities) }
     specify { expect { city.import dummy_cities }.to update_index(city).and_reindex(dummy_cities) }
     specify { expect { city.import dummy_cities.map(&:id) }.to update_index(city).and_reindex(dummy_cities) }
 


### PR DESCRIPTION
Encountered this issue when trying to implement .deep_import

I attempted to implement deep_import without using the splat'd args approach and nil as a default for the first arg. This seemed to work fine except that when the default was passed through Chewy treated it as `nil == []` (In truth it may actually have treated it as the nil scope and not the empty array).

Not sure what you (@pyromaniac) view as the correct behavior. If you agree that .import(nil) should be treated as .import() then this PR will resolve same. If you disagree and feel that .import(nil) should continue to be treated as .import([]), please let me know and I'll open a separate PR that adds comments and specs to reflect the intent.

Currently .import() imports the default data set and .import([]) imports the empty data set.
Currently .import(nil) imports the empty data set.

This PR changes the behavior to be equivalent to the .import() method