### PR TITLE
Accept table name for update_index as a Proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ See [config.rb](lib/chewy/config.rb) for more details.
     update_index('users') { users } # if index has only one type
                                     # there is no need to specify updated type
   end
+
+  class Book < ActiveRecord::Base
+    update_index(->(book) {"books#book_#{book.language}"}) { self } # dynamic index and type with Proc.
+                                                                    # For book with language == "en"
+                                                                    # this code will generate `books#book_en`
+  end
   ```
 
   Also, you can use second argument for method name passing:

--- a/lib/chewy/type/observe.rb
+++ b/lib/chewy/type/observe.rb
@@ -16,6 +16,8 @@ module Chewy
             instance_eval(&block)
           end
 
+          type_name = type_name.call(self) if type_name.is_a?(Proc)
+
           Chewy.derive_type(type_name).update_index(backreference, options)
         end
       end

--- a/spec/chewy/type/observe_spec.rb
+++ b/spec/chewy/type/observe_spec.rb
@@ -10,6 +10,10 @@ describe Chewy::Type::Import do
 
     let(:backreferenced) { 3.times.map { |i| double(id: i) } }
 
+    specify { expect { DummiesIndex.dummy.update_index("dummies#dummy") }
+      .to update_index('dummies#dummy') }
+    specify { expect { DummiesIndex.dummy.update_index(->(dummy) {"dummies#dummy"}) }
+      .to update_index('dummies#dummy') }
     specify { expect { DummiesIndex.dummy.update_index(backreferenced) }
       .to raise_error Chewy::UndefinedUpdateStrategy }
     specify { expect { DummiesIndex.dummy.update_index([]) }


### PR DESCRIPTION
Hello! I'm using "One Language per Document" pattern (https://www.elastic.co/guide/en/elasticsearch/guide/current/one-lang-docs.html) and I need to define types dynamically. My PR will help with this issue.

Example:
```ruby
class BooksIndex < Chewy::Index
  %w(ru en).each do |language|
    define_type Book.where(language: language), name: "book_#{language}" do
      field :title, type: 'string', analyzer: language
    end
  end
end

class Book < ActiveRecord::Base
  update_index(->(book) {"books#book_#{book.language}"}) { self }
end
```