### PR TITLE
Add tasks.rb to simplify loading rake tasks

### DIFF
--- a/lib/chewy/tasks.rb
+++ b/lib/chewy/tasks.rb
@@ -1,0 +1,3 @@
+Dir[File.expand_path('../../tasks/*.rake', __FILE__)].sort.each do |file|
+  load file
+end


### PR DESCRIPTION
Now you can load chewy rake tasks in the application's Rakefile like this:

    require 'chewy/tasks'