### PR TITLE
Require only core extensions which are actually used

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -1,9 +1,18 @@
-require 'active_support'
-require 'active_support/log_subscriber'
-require 'active_support/deprecation'
-require 'active_support/core_ext'
 require 'active_support/concern'
+require 'active_support/deprecation'
 require 'active_support/json'
+require 'active_support/log_subscriber'
+
+require 'active_support/core_ext/array/access'
+require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/enumerable'
+require 'active_support/core_ext/hash/reverse_merge'
+require 'active_support/core_ext/numeric/time'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/inclusion'
+require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/string/starts_ends_with'
+
 require 'i18n/core_ext/hash'
 require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
 require 'singleton'

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -11,7 +11,6 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/string/inflections'
-require 'active_support/core_ext/string/starts_ends_with'
 
 require 'i18n/core_ext/hash'
 require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -982,7 +982,7 @@ module Chewy
 
     def _derive_index index_name
       (@derive_index ||= {})[index_name] ||= _indexes_hash[index_name] ||
-        _indexes_hash[_indexes_hash.keys.sort_by(&:length).reverse.detect { |name| index_name.starts_with?(name) }]
+        _indexes_hash[_indexes_hash.keys.sort_by(&:length).reverse.detect { |name| index_name.start_with?(name) }]
     end
 
     def _indexes_hash


### PR DESCRIPTION
The aim is to reduce monkey patching of core classes which is undesirable, especially when this gem is used outside of Rails app.