### PR TITLE
fix-duplicate-ids-on-index-import -> now with better performance

### DIFF
--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -38,7 +38,8 @@ module Chewy
         end
 
         def pluck_ids(scope)
-          scope.pluck("distinct(#{target.table_name}.#{target.primary_key})")
+          scope.dup.tap{|r| r.includes_values = []}
+            .pluck("distinct(#{target.table_name}.#{target.primary_key})")
         end
 
         def scope_where_ids_in(scope, ids)

--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -38,8 +38,7 @@ module Chewy
         end
 
         def pluck_ids(scope)
-          scope.dup.tap{|r| r.includes_values = []}
-            .pluck("distinct(#{target.table_name}.#{target.primary_key})")
+          scope.except(:includes).pluck("distinct(#{target.table_name}.#{target.primary_key})")
         end
 
         def scope_where_ids_in(scope, ids)

--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -38,7 +38,7 @@ module Chewy
         end
 
         def pluck_ids(scope)
-          scope.except(:includes).pluck("distinct(#{target.table_name}.#{target.primary_key})")
+          scope.except(:includes).uniq.pluck(target.primary_key.to_sym)
         end
 
         def scope_where_ids_in(scope, ids)


### PR DESCRIPTION
Hi again!
Here in my company we are relying heavily on Chewy right now, and we are looking for performance bottlenecks, since we are using some complex views in the database right now.

Regarding https://github.com/toptal/chewy/issues/214, we saw that still we could make it faster if we somehow could remove all the OUTER JOINS that come up in the query as a result of eager loading with Active Record's include. So I asked around at StackOverflow (http://stackoverflow.com/questions/31436175/in-an-activerecord-relation-with-eager-loading-how-can-you-pluck-the-primary-co#comment-50842906), and someone came up with a way to do just that.

Do you think there might be any unintended side-effect because of that? I'm still waiting for the tests to pass...