### PR TITLE
Revert "Fix pluck_ids method for ActiveRecord adapter"

### DIFF
--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -38,7 +38,7 @@ module Chewy
         end
 
         def pluck_ids(scope)
-          scope.except(:includes, :order).uniq.pluck(target.primary_key.to_sym)
+          scope.except(:includes).uniq.pluck(target.primary_key.to_sym)
         end
 
         def scope_where_ids_in(scope, ids)

--- a/spec/chewy/type/adapter/active_record_spec.rb
+++ b/spec/chewy/type/adapter/active_record_spec.rb
@@ -1,11 +1,7 @@
 require 'spec_helper'
 
 describe Chewy::Type::Adapter::ActiveRecord, :active_record do
-  before do
-    stub_model(:city) do
-      belongs_to :country
-    end
-  end
+  before { stub_model(:city) }
 
   describe '#name' do
     specify { expect(described_class.new(City).name).to eq('City') }
@@ -47,7 +43,6 @@ describe Chewy::Type::Adapter::ActiveRecord, :active_record do
       let!(:cities) { 3.times.map { City.create! } }
 
       specify { expect(subject.identify(City.where(nil))).to match_array(cities.map(&:id)) }
-      specify { expect(subject.identify(City.includes(:country).order('countries.id'))).to match_array(cities.map(&:id)) }
       specify { expect(subject.identify(cities)).to eq(cities.map(&:id)) }
       specify { expect(subject.identify(cities.first)).to eq([cities.first.id]) }
       specify { expect(subject.identify(cities.first(2).map(&:id))).to eq(cities.first(2).map(&:id)) }


### PR DESCRIPTION
Reverts toptal/chewy#229

It breaks import! With no order batch load fails.