### PR TITLE
Implement naive named aggregations

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,50 @@ The response will include the `:facets` sidechannel:
 < { ... ,"facets":{"countries":{"_type":"terms","missing":?,"total":?,"other":?,"terms":[{"term":"USA","count":?},{"term":"Brazil","count":?}, ...}}
 ```
 
+### Aggregations
+
+Aggregations are part of the optional sidechannel that can be requested with a query.
+
+You interact with aggregations using the composable #aggregations method (or its alias #aggs)
+
+Let's look at an example.
+
+```ruby
+class UsersIndex < Chewy::Index
+  define_type User do
+    field :name
+    field :rating
+  end
+end
+
+all_johns = UsersIndex::User.filter { name == 'john' }.aggs({ avg_rating: { avg: { field: 'rating' } } })
+
+avg_johns_rating = all_johns.aggs
+# => {"avg_rating"=>{"value"=>3.5}}
+```
+
+It is convenient to name aggregations that you intend to reuse regularly. This is achieve with the .aggregation method,
+which is also available under the .agg alias method.
+
+Here's the same example from before
+
+```ruby
+class UsersIndex < Chewy::Index
+  define_type User do
+    field :name
+    field :rating
+    agg :avg_rating do
+      { avg: { field: 'rating' } }
+    end
+  end
+end
+
+all_johns = UsersIndex::User.filter { name == 'john' }.aggs(:avg_rating)
+
+avg_johns_rating = all_johns.aggs
+# => {"avg_rating"=>{"value"=>3.5}}
+```
+
 ### Script fields
 
 Script fields allow you to execute Elasticsearch's scripting languages such as groovy and javascript. More about supported languages and what scripting is [here](https://www.elastic.co/guide/en/elasticsearch/reference/0.90/modules-scripting.html). This feature allows you to calculate the distance between geo points, for example. This is how to use the DSL:

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -511,13 +511,28 @@ module Chewy
     #          }}
     #
     def aggregations params = nil
+      @_named_aggs ||= _build_named_aggs
       if params
+        params = { params => @_named_aggs[params]} if params.is_a?(Symbol)
         chain { criteria.update_aggregations params }
       else
         _response['aggregations'] || {}
       end
     end
     alias :aggs :aggregations
+
+    # In this simplest of implementations each named aggregation must be uniquely named
+    def _build_named_aggs
+      named_aggs = {}
+      @_indexes.each do |index|
+        index.types.each do |type|
+          type.agg_defs.each do |agg_name, prc|
+            named_aggs[agg_name] = prc.call
+          end
+        end
+      end
+      named_aggs
+    end
 
     # Sets elasticsearch <tt>suggest</tt> search request param
     #

--- a/lib/chewy/type/mapping.rb
+++ b/lib/chewy/type/mapping.rb
@@ -118,6 +118,35 @@ module Chewy
           end
         end
 
+        # Defines an aggregation that can be bound to a query or filter
+        #
+        #   Suppose that a user has posts and each post has ratings
+        #   avg_post_rating is the mean of all ratings
+        #
+        #   class UsersIndex < Chewy::Index
+        #     define_type User do
+        #       field :posts do
+        #         field :rating
+        #       end
+        #
+        #       agg :avg_rating do
+        #         { avg: { field: 'posts.rating' } }
+        #       end
+        #     end
+        #   end
+        def agg *args, &block
+          options = args.extract_options!
+          build_root unless root_object
+
+          @_agg_defs ||= {}
+          @_agg_defs[args.first] = block
+        end
+        alias_method :aggregation, :agg
+
+        def agg_defs
+          @_agg_defs || {}
+        end
+
         # Defines dynamic template in mapping root objects
         #
         #   class CarsIndex < Chewy::Index

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -213,6 +213,34 @@ describe Chewy::Query do
     specify { expect(subject.aggregations(aggregation1: {field: 'hello'}).criteria.aggregations).to include(aggregation1: {field: 'hello'}) }
     specify { expect { subject.aggregations(aggregation1: {field: 'hello'}) }.not_to change { subject.criteria.aggregations } }
 
+    context 'when requesting a named aggregation' do
+      before do
+        stub_index(:products) do
+          define_type :product do
+            root do
+              field :name, 'surname'
+              field :title, type: 'string' do
+                field :subfield1
+              end
+              field 'price', type: 'float' do
+                field :subfield2
+              end
+              agg :named_agg do
+                { avg: { field: 'title.subfield1' } }
+              end
+            end
+          end
+          define_type :person do
+            root do
+              field :name
+            end
+          end
+        end
+      end
+
+      specify { expect(subject.aggregations(:named_agg).criteria.aggregations).to include(named_agg: { avg: { field: 'title.subfield1' } }) }
+    end
+
     context 'results', :orm do
       before { stub_model(:city) }
       let(:cities) { 10.times.map { |i| City.create! id: i + 1, name: "name#{i}", rating: i % 3 } }

--- a/spec/chewy/type/mapping_spec.rb
+++ b/spec/chewy/type/mapping_spec.rb
@@ -14,9 +14,16 @@ describe Chewy::Type::Mapping do
           field 'price', type: 'float' do
             field :subfield2
           end
+          agg :named_agg do
+            { avg: { field: 'title.subfield1' } }
+          end
         end
       end
     end
+  end
+
+  describe '.agg' do
+    specify { expect(product.agg_defs[:named_agg].call).to eq({ avg: { field: 'title.subfield1' } }) }
   end
 
   describe '.field' do


### PR DESCRIPTION
Add a naive approach for declaring and using named aggregations.

I don't have a specific plan or convention for providing namespaced named aggregations. I'd just allow / force the user to handle this or I could try and impose a `index#type.agg_name` sort of convention.

Do you have a preference @pyromaniac ?

#192 

I'll work on adding the `index#doc_type.agg_name` syntax in the next pr.

@pyromaniac please merge at your discretion.