### PR TITLE
In rake tasks, only search Rails engines with defined app/chewy folders

### DIFF
--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -17,7 +17,7 @@ module Chewy
       end
 
       def eager_load_chewy!
-        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths['app/chewy'].existent }.flatten.uniq
+        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths['app/chewy'] }.compact.map(&:existent).flatten.uniq
 
         dirs.each do |dir|
           Dir.glob(File.join(dir, '**/*.rb')).each do |file|


### PR DESCRIPTION
When running the "update all" or "reset all" rake tasks, Chewy would
search all "app/chewy" folders for each Rails engine for indexes to
update or reset. However, if a Rails engine did not have an app/chewy
folder defined, the rake task would fail. This change compacts the
folder list to first remove the list of Rails engines that do not have
the folder defined, before checking to see if there are any existing
indexes in those folders.