### PR TITLE
Add Query#objects

### DIFF
--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -39,6 +39,7 @@ module Chewy
       @_indexes = indexes_or_types_and_options.select { |klass| klass < Chewy::Index }
       @_indexes |= @_types.map(&:index)
       @criteria = Criteria.new
+      @objects = []
     end
 
     # Comparation with other query or collection
@@ -978,6 +979,13 @@ module Chewy
         criteria.options[:preload] && criteria.options[:loaded_objects] ?
           _results.map(&:_object) : _results
       end
+    end
+    
+    def objects
+      return @objects if @objects.present?
+      _load_objects!
+      @objects = _collection.map(&:_object)
+      @objects
     end
 
     def _derive_index index_name


### PR DESCRIPTION
Added an easier to use `Query#objects` method.

It does the same thing as `UsersIndex.filter(range: {rating: {gte: 100}}).preload(...).query(...).map(&:_object)` - https://github.com/toptal/chewy#objects-loading

But now it can be done faster as `UsersIndex.filter(range: {rating: {gte: 100}}).query(...).objects`
