### PR TITLE
Fix rspec-specific warnings

### DIFF
--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -54,8 +54,8 @@ describe Chewy::Index::Actions do
 
     context do
       before { DummiesIndex.create }
-      specify { expect { DummiesIndex.create! }.to raise_error }
-      specify { expect { DummiesIndex.create!('2013') }.to raise_error }
+      specify { expect { DummiesIndex.create! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
+      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
     end
 
     context do
@@ -64,7 +64,7 @@ describe Chewy::Index::Actions do
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
       specify { expect(DummiesIndex.aliases).to eq([]) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
-      specify { expect { DummiesIndex.create!('2013') }.to raise_error }
+      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
       specify { expect(DummiesIndex.create!('2014')["acknowledged"]).to eq(true) }
 
       context do
@@ -128,8 +128,8 @@ describe Chewy::Index::Actions do
   end
 
   describe '.delete!' do
-    specify { expect { DummiesIndex.delete! }.to raise_error }
-    specify { expect { DummiesIndex.delete!('2013') }.to raise_error }
+    specify { expect { DummiesIndex.delete! }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound) }
+    specify { expect { DummiesIndex.delete!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound) }
 
     context do
       before { DummiesIndex.create }

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -54,8 +54,8 @@ describe Chewy::Index::Actions do
 
     context do
       before { DummiesIndex.create }
-      specify { expect { DummiesIndex.create! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
-      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
+      specify { expect { DummiesIndex.create! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/\[\[dummies\] already exists\]/) }
+      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/Invalid alias name \[dummies\]/) }
     end
 
     context do
@@ -64,7 +64,7 @@ describe Chewy::Index::Actions do
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
       specify { expect(DummiesIndex.aliases).to eq([]) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
-      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest) }
+      specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/\[\[dummies_2013\] already exists\]/) }
       specify { expect(DummiesIndex.create!('2014')["acknowledged"]).to eq(true) }
 
       context do

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -14,7 +14,7 @@ describe Chewy::Strategy do
   end
 
   describe '#push' do
-    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError).with_message(/uninitialized constant Chewy::Strategy::Unexistant/) }
+    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError).with_message(/uninitialized constant.*Unexistant/) }
 
     specify do
       expect { strategy.push(:atomic) }

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -14,7 +14,7 @@ describe Chewy::Strategy do
   end
 
   describe '#push' do
-    specify { expect { strategy.push(:unexistant) }.to raise_error }
+    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError) }
 
     specify do
       expect { strategy.push(:atomic) }
@@ -24,7 +24,7 @@ describe Chewy::Strategy do
   end
 
   describe '#pop' do
-    specify { expect { strategy.pop }.to raise_error }
+    specify { expect { strategy.pop }.to raise_error(RuntimeError).with_message(/Can't pop root strategy/) }
 
     specify do
       strategy.push(:urgent)

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -14,7 +14,7 @@ describe Chewy::Strategy do
   end
 
   describe '#push' do
-    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError) }
+    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError).with_message(/uninitialized constant Chewy::Strategy::Unexistant/) }
 
     specify do
       expect { strategy.push(:atomic) }


### PR DESCRIPTION
This fixes a few rspec-related warnings I've spotted during initial test runs.