### PR TITLE
Do not perform sidekiq workers if no ids present

### DIFF
--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -19,7 +19,9 @@ module Chewy
       end
 
       def leave
-        @stash.all? { |type, ids| Chewy::Strategy::Sidekiq::Worker.perform_async(type.name, ids) }
+        @stash.each do |type, ids|
+          Chewy::Strategy::Sidekiq::Worker.perform_async(type.name, ids) unless ids.empty?
+        end
       end
     end
   end


### PR DESCRIPTION
When I set request_strategy to sidekiq I have many object updates. I have many sidekiq jobs for update in queue. It's ok. But if nil return in observe callback like this 
`update_index('users#user') { self if user_have_changes? }` I get many sidekiq jobs with `[]` argument

![image](https://cloud.githubusercontent.com/assets/64508/10338789/8f76d0ce-6d10-11e5-9cb5-e08c8cc712cc.png)

Maybe it would be better not to perform sidekiq worker when there no ids?