### PR TITLE
Active job queue

### DIFF
--- a/lib/chewy/strategy/active_job.rb
+++ b/lib/chewy/strategy/active_job.rb
@@ -11,6 +11,8 @@ module Chewy
     #
     class ActiveJob < Atomic
       class Worker < ::ActiveJob::Base
+        queue_as :chewy
+
         def perform(type, ids)
           type.constantize.import!(ids)
         end

--- a/spec/chewy/strategy/active_job_spec.rb
+++ b/spec/chewy/strategy/active_job_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 if defined?(::ActiveJob)
   describe Chewy::Strategy::ActiveJob do
     around { |example| Chewy.strategy(:bypass) { example.run } }
+    before(:all) do
+      ::ActiveJob::Base.logger = Chewy.logger
+    end
     before do
       ::ActiveJob::Base.queue_adapter = :test
       ::ActiveJob::Base.queue_adapter.enqueued_jobs.clear

--- a/spec/chewy/strategy/active_job_spec.rb
+++ b/spec/chewy/strategy/active_job_spec.rb
@@ -28,6 +28,15 @@ if defined?(::ActiveJob)
     end
 
     specify do
+      Chewy.strategy(:active_job) do
+        [city, other_city].map(&:save!)
+      end
+      enqueued_job = ::ActiveJob::Base.queue_adapter.enqueued_jobs.first
+      expect(enqueued_job[:job]).to eq(Chewy::Strategy::ActiveJob::Worker)
+      expect(enqueued_job[:queue]).to eq('chewy')
+    end
+
+    specify do
       ::ActiveJob::Base.queue_adapter = :inline
       expect { [city, other_city].map(&:save!) }
         .to update_index(CitiesIndex::City, strategy: :active_job)


### PR DESCRIPTION
Follow up to #266.

Uses the 'chewy' queue for active job jobs. Gets rid of excess active job logging in tests.