### PR TITLE
use the configured assets prefix instead of hardcoding /assets

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -10,7 +10,7 @@ module Chewy
       end
 
       def call(env)
-        if env['PATH_INFO'].start_with?('/assets/')
+        if env['PATH_INFO'].start_with?(Rails.application.config.assets.prefix)
           @app.call(env)
         else
           Chewy.strategy(Chewy.request_strategy) { @app.call(env) }


### PR DESCRIPTION
In our app we have configured a different assets prefix since we have an `AssetsController` with corresponding routes. In this controller, the request strategy is not being used, but should be.