### PR TITLE
Safely unsubscribe Notifications subscriber.

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -57,9 +57,10 @@ module Chewy
             errors = args.last[:errors]
           end
           import *args
-          ActiveSupport::Notifications.unsubscribe(subscriber)
           raise Chewy::ImportFailed.new(self, errors) if errors.present?
           true
+        ensure
+          ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
         end
 
         # Wraps elasticsearch-ruby client indices bulk method.

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -349,5 +349,16 @@ describe Chewy::Type::Import do
 
       specify { expect { city.import!(dummy_cities) }.to raise_error Chewy::ImportFailed }
     end
+
+    context 'when .import fails' do
+      before do
+        allow(city).to receive(:import) { raise }
+      end
+
+      specify do
+        expect(ActiveSupport::Notifications).to receive(:unsubscribe)
+        city.import!(dummy_cities) rescue nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello!

Unsubscription should be done safely and here is the fix.

This bug is not as inoffensive as it seems at first sight. Block passed to `subscribe` *captures* method `*args` (fat activerecord objects, maybe with references to loaded associations). These captured objects are never garbage collected.

Needless to say that it also overwhelms the callback chain that slows everything down.