### PR TITLE
Update Atomic strategy to respect the root _id evaluator if provided

### DIFF
--- a/lib/chewy/strategy/atomic.rb
+++ b/lib/chewy/strategy/atomic.rb
@@ -20,7 +20,7 @@ module Chewy
         ActiveSupport::Deprecation.warn("`urgent: true` option is deprecated and is not effective inside `:atomic` strategy, use `Chewy.strategy(:urgent)` strategy instead") if options.key?(:urgent)
 
         @stash[type] ||= []
-        @stash[type] |= type.adapter.identify(objects)
+        @stash[type] |= type.identify objects
       end
 
       def leave

--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -41,6 +41,18 @@ module Chewy
       adapter.type_name
     end
 
+    # Returns the identifier value
+    #
+    def self.identify objects
+      case root_object
+        # Handle case in specs where root_object is nil, or where root_object is a string or integer
+        when NilClass, String, Fixnum
+          adapter.identify(objects)
+        else
+          Array(root_object.compose_id(objects) || adapter.identify(objects))
+      end
+    end
+
     # Returns list of public class methods defined in current type
     #
     def self.scopes

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -86,12 +86,7 @@ module Chewy
 
         # Returns the value of the identifier for an object
         def root_object_identifier object
-          case object
-            when String, Fixnum
-              object
-            else
-              root_object.compose_id object
-          end
+          Array(identify object).first
         end
 
         def delete_bulk_entry(object, indexed_objects = nil, crutches = nil)

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -60,6 +60,29 @@ describe Chewy::Strategy do
         expect(CitiesIndex::City).to receive(:import).with([city.id, other_city.id]).once
         Chewy.strategy(:atomic) { [city, other_city].map(&:save!) }
       end
+
+      context "when a root _id evaluator is provided" do
+        before do
+          stub_index(:cities) do
+            define_type City do
+              root _id: -> { name } do
+              end
+            end
+          end
+        end
+
+        specify do
+          expect(CitiesIndex::City).to receive(:import).with([city.name, other_city.name]).once
+          Chewy.strategy(:atomic) { [city, other_city].map(&:save!) }
+        end
+
+        specify do
+          # We really want to assert that #delete_bulk_entry is invoked, but #import seems the best
+          # public method that surrounds the call to #delete_bulk_entry
+          expect(CitiesIndex::City).to receive(:import).with([city.name, other_city.name]).once
+          Chewy.strategy(:atomic) { [city, other_city].map(&:destroy!) }
+        end
+      end
     end
 
     context do


### PR DESCRIPTION
 - Include spec of behavior when a root object is provided (with and without _id evaluator methods)

TODO

- [ ] Remove chewy/type/import.rb L91 and L111 pending further info from @pyromaniac 