### PR TITLE
Check current rspec.mock_framework instead of simple usage of defined?

### DIFF
--- a/lib/chewy/rspec/update_index.rb
+++ b/lib/chewy/rspec/update_index.rb
@@ -194,7 +194,7 @@ RSpec::Matchers.define :update_index do |type_name, options = {}|
   end
 
   def agnostic_stub
-    if defined? Mocha
+    if defined?(Mocha) && RSpec.configuration.mock_framework.to_s == 'RSpec::Core::MockingAdapters::Mocha'
       "type.stubs(:bulk).with"
     else
       "allow(type).to receive(:bulk)"


### PR DESCRIPTION
There is a bug when we have mocha in Gemfile but not use it as mock framework in rspec.