### PR TITLE
use .all when loading sequel models, identify is the same as in Orm, …

### DIFF
--- a/lib/chewy/type/adapter/orm.rb
+++ b/lib/chewy/type/adapter/orm.rb
@@ -94,13 +94,7 @@ module Chewy
           additional_scope = load_options[load_options[:_type].type_name.to_sym].try(:[], :scope) || load_options[:scope]
 
           scope = all_scope_where_ids_in(objects.map(&primary_key))
-          loaded_objects = if additional_scope.is_a?(Proc)
-            scope.instance_exec(&additional_scope)
-          elsif additional_scope.is_a?(relation_class) && scope.respond_to?(:merge)
-            scope.merge(additional_scope)
-          else
-            scope
-          end.index_by { |object| object.public_send(primary_key).to_s }
+          loaded_objects = load_scope_objects(scope, additional_scope).index_by { |object| object.public_send(primary_key).to_s }
 
           objects.map { |object| loaded_objects[object.public_send(primary_key).to_s] }
         end
@@ -147,6 +141,16 @@ module Chewy
 
         def model_of_relation relation
           relation.klass
+        end
+
+        def load_scope_objects(scope, additional_scope = nil)
+          if additional_scope.is_a?(Proc)
+            scope.instance_exec(&additional_scope)
+          elsif additional_scope.is_a?(relation_class) && scope.respond_to?(:merge)
+            scope.merge(additional_scope)
+          else
+            scope
+          end
         end
       end
     end

--- a/lib/chewy/type/adapter/sequel.rb
+++ b/lib/chewy/type/adapter/sequel.rb
@@ -13,16 +13,6 @@ module Chewy
             target.is_a?(::Sequel::Dataset))
         end
 
-        def identify collection
-          if collection.is_a?(relation_class)
-            pluck_ids(collection)
-          else
-            Array.wrap(collection).map do |entity|
-              entity.is_a?(object_class) ? entity.public_send(primary_key) : entity
-            end
-          end
-        end
-
       private
 
         def cleanup_default_scope!
@@ -40,7 +30,7 @@ module Chewy
           result = true
 
           while ids.any?
-            result &= yield grouped_objects(default_scope_where_ids_in(ids))
+            result &= yield grouped_objects(default_scope_where_ids_in(ids).all)
             break if ids.size < batch_size
             ids = pluck_ids(scope.where { |o| o.__send__(primary_key) > ids.last })
           end
@@ -50,6 +40,10 @@ module Chewy
 
         def primary_key
           target.primary_key
+        end
+
+        def all_scope
+          target.dataset
         end
 
         def pluck_ids(scope)
@@ -70,6 +64,10 @@ module Chewy
 
         def object_class
           ::Sequel::Model
+        end
+
+        def load_scope_objects(*args)
+          super.all
         end
       end
     end


### PR DESCRIPTION
some improvements for the sequel adapter