### PR TITLE
add client_class option

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -122,7 +122,10 @@ module Chewy
     # Main elasticsearch-ruby client instance
     #
     def client
-      Thread.current[:chewy_client] ||= ::Elasticsearch::Client.new configuration
+      Thread.current[:chewy_client] ||= begin
+        klass = configuration[:client_class] || ::Elasticsearch::Client
+        klass.new configuration
+      end
     end
 
     # Sends wait_for_status request to ElasticSearch with status

--- a/spec/chewy_spec.rb
+++ b/spec/chewy_spec.rb
@@ -110,4 +110,18 @@ describe Chewy do
     specify { expect(DevelopersIndex.exists?).to eq(false) }
     specify { expect(CompaniesIndex.exists?).to eq(false) }
   end
+
+  describe '.client' do
+    let!(:initial_client) { Thread.current[:chewy_client] }
+    let(:klass) { Class.new(::Elasticsearch::Transport::Client) }
+
+    before do
+      Thread.current[:chewy_client] = nil
+      allow(Chewy).to receive_messages(configuration: { client_class: klass })
+    end
+
+    its(:client) { is_expected.to be_a klass }
+
+    after { Thread.current[:chewy_client] = initial_client }
+  end
 end


### PR DESCRIPTION
A use case for it is setting up a connection to AWS Elasticsearch.

According to elasticsearch-transport's [readme](https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-transport#transport-implementations) one should pass a block to `::ElasticsearchClient#initialize` which adds necessary authorization headers to each request. However this can't be done with chewy.

A possible hack as it was discussed in the issue https://github.com/toptal/chewy/issues/296 is to assign `Thread.current[:chewy_client]` somewhere (say, in Rails initializer) with a custom instance. But this would affect only the current thread.

With `:client_class` option it becomes possible to perfom dependency injection of a custom client class which gets instantiated in every thread you call `Chewy.client`.

So an example initializer for AWS tuning looks like this:
```ruby
require 'faraday_middleware/aws_signers_v4'

class AwsElasticsearchClient < ::Elasticsearch::Client
  def initialize(options)
    super(options) do |f|
      f.request :aws_signers_v4,
                service_name: 'es',
                region: 'us-east-1',
                credentials: Aws::Credentials.new(
                  ENV['AWS_ACCESS_KEY'],
                  ENV['AWS_SECRET_ACCESS_KEY'])
    end
  end
end

Chewy.configuration[:chewy_client] = AwsElasticsearchClient
```