### PR TITLE
add proc transport option

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -122,7 +122,10 @@ module Chewy
     # Main elasticsearch-ruby client instance
     #
     def client
-      Thread.current[:chewy_client] ||= ::Elasticsearch::Client.new configuration
+      Thread.current[:chewy_client] ||= begin
+        block = configuration[:transport_options].try { |c| c[:proc] }
+        ::Elasticsearch::Client.new(configuration, &block)
+      end
     end
 
     # Sends wait_for_status request to ElasticSearch with status

--- a/spec/chewy_spec.rb
+++ b/spec/chewy_spec.rb
@@ -110,4 +110,20 @@ describe Chewy do
     specify { expect(DevelopersIndex.exists?).to eq(false) }
     specify { expect(CompaniesIndex.exists?).to eq(false) }
   end
+
+  describe '.client' do
+    let!(:initial_client) { Thread.current[:chewy_client] }
+    let(:block) { proc { } }
+    let(:mock_client) { double(:client) }
+
+    before do
+      Thread.current[:chewy_client] = nil
+      allow(Chewy).to receive_messages(configuration: { transport_options: { proc: block } })
+      allow(::Elasticsearch::Client).to receive(:new).with(Chewy.configuration, &block).and_return(mock_client)
+    end
+
+    its(:client) { is_expected.to eq(mock_client) }
+
+    after { Thread.current[:chewy_client] = initial_client }
+  end
 end


### PR DESCRIPTION
A use case for it is setting up a connection to AWS Elasticsearch.

According to elasticsearch-transport's readme one should pass a block to ::ElasticsearchClient#initialize which adds necessary authorization headers to each request. However this can't be done with chewy.

A possible hack as it was discussed in the issue #296 is to assign Thread.current[:chewy_client] somewhere (say, in Rails initializer) with a custom instance. But this would affect only the current thread.

With `:proc` option it becomes possible to pass a block to `Elasticsearch::Constructor`.

So an example initializer for AWS tuning looks like this:

```ruby
require 'faraday_middleware/aws_signers_v4'

Chewy.configuration[:transport_options] = {
  headers: { content_type: 'application/json' },
  proc: -> (f) do
      f.request :aws_signers_v4,
                service_name: 'es',
                region: 'us-east-1',
                credentials: Aws::Credentials.new(
                  ENV['AWS_ACCESS_KEY'],
                  ENV['AWS_SECRET_ACCESS_KEY'])
  end
}
```

P.S. For the purpose of `Content-Type` header see issue https://github.com/toptal/chewy/issues/271.