### PR TITLE
Guard against assets not being configured

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -10,7 +10,8 @@ module Chewy
       end
 
       def call(env)
-        if env['PATH_INFO'].start_with?(Rails.application.config.assets.prefix)
+        # For Rails applications in `api_only` mode, the `assets` config isn't present
+        if Rails.application.config.respond_to?(:assets) && env['PATH_INFO'].start_with?(Rails.application.config.assets.prefix)
           @app.call(env)
         else
           Chewy.strategy(Chewy.request_strategy) { @app.call(env) }


### PR DESCRIPTION
The change in #277 unfortunately breaks Rails applications in API mode (Rails 5 or via the `rails-api` gem): When configuring an application API only, the `Rails.application.config.assets` entry isn't available and the `RequestStrategy` middleware crashes the application. This now checks if the application is running on api-only mode and does the test for the assets-path afterwards.