### PR TITLE
Better error handling in Chewy::Strategy#wrap

### DIFF
--- a/lib/chewy/strategy.rb
+++ b/lib/chewy/strategy.rb
@@ -56,10 +56,10 @@ module Chewy
     end
 
     def wrap name
-      push name
+      stack = push(name)
       yield
     ensure
-      pop
+      pop if stack
     end
 
   private
@@ -72,7 +72,11 @@ module Chewy
     end
 
     def resolve name
-      "Chewy::Strategy::#{name.to_s.camelize}".constantize or raise "Can't find update strategy `#{name}`"
+      "Chewy::Strategy::#{name.to_s.camelize}".safe_constantize or raise "Can't find update strategy `#{name}`"
+    rescue NameError => ex
+      # WORKAROUND: Strange behavior of `safe_constantize` with mongoid gem
+      raise "Can't find update strategy `#{name}`" if ex.name.to_s.demodulize == name.to_s.camelize
+      raise
     end
   end
 end

--- a/spec/chewy/strategy_spec.rb
+++ b/spec/chewy/strategy_spec.rb
@@ -14,7 +14,7 @@ describe Chewy::Strategy do
   end
 
   describe '#push' do
-    specify { expect { strategy.push(:unexistant) }.to raise_error(NameError).with_message(/uninitialized constant.*Unexistant/) }
+    specify { expect { strategy.push(:unexistant) }.to raise_error(RuntimeError).with_message("Can't find update strategy `unexistant`") }
 
     specify do
       expect { strategy.push(:atomic) }
@@ -31,6 +31,18 @@ describe Chewy::Strategy do
       expect { strategy.pop }
         .to change { strategy.current }
         .to(an_instance_of(Chewy::Strategy::Base))
+    end
+  end
+
+  describe '#wrap' do
+    specify { expect { strategy.wrap(:unexistant) {} }.to raise_error(RuntimeError).with_message("Can't find update strategy `unexistant`") }
+
+    specify do
+      expect do
+        strategy.wrap(:urgent) do
+          expect(strategy.current).to be_a(Chewy::Strategy::Urgent)
+        end
+      end.not_to change { strategy.current }
     end
   end
 


### PR DESCRIPTION
Passing non-exising strategy to Chewy::Strateg#wrap caused unclear error: "Can't pop root strategy". Now, push and wrap give back better error when strategy is missing.