### PR TITLE
Do not overwrite attributes with highlights

### DIFF
--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -18,16 +18,6 @@ module Chewy
     include Loading
     include Pagination
 
-    RESULT_MERGER = lambda do |key, old_value, new_value|
-      if old_value.is_a?(Hash) && new_value.is_a?(Hash)
-        old_value.merge(new_value, &RESULT_MERGER)
-      elsif new_value.is_a?(Array) && new_value.count > 1
-        new_value
-      else
-        old_value.is_a?(Array) ? new_value : new_value.first
-      end
-    end
-
     delegate :each, :count, :size, to: :_collection
     alias_method :to_ary, :to_a
 
@@ -1005,8 +995,8 @@ module Chewy
 
     def _results
       @_results ||= (criteria.none? || _response == {} ? [] : _response['hits']['hits']).map do |hit|
-        attributes = (hit['_source'] || {}).merge(hit['highlight'] || {}, &RESULT_MERGER)
-        attributes.reverse_merge!(id: hit['_id'])
+        attributes = (hit['_source'] || {})
+          .reverse_merge(id: hit['_id'])
           .merge!(_score: hit['_score'])
           .merge!(_explanation: hit['_explanation'])
 

--- a/lib/chewy/type/wrapper.rb
+++ b/lib/chewy/type/wrapper.rb
@@ -19,16 +19,34 @@ module Chewy
         end
       end
 
-      def method_missing(method, *args, &block)
-        if @attributes.key?(method.to_s)
-          @attributes[method.to_s]
-        else
-          nil
+      def method_missing(method_name, *args, &block)
+        method_name.to_s.match(/_highlight\z/) do |match|
+          return highlight(match.pre_match) if highlight?(match.pre_match)
         end
+        return @attributes[method_name.to_s] if @attributes.key?(method_name.to_s)
+        return nil if attribute_defined?(method_name.to_s)
+        super
       end
 
-      def respond_to_missing?(method, _)
-        @attributes.key?(method.to_s) || super
+      def respond_to_missing?(method_name, include_private = false)
+        method_name.to_s.match(/_highlight\z/) { |m| highlight?(m.pre_match) } ||
+          @attributes.key?(method_name.to_s) ||
+          attribute_defined?(method_name.to_s) ||
+          super
+      end
+
+      private
+
+      def attribute_defined?(attribute)
+        self.class.root_object && self.class.root_object.children.find { |a| a.name.to_s == attribute }.present?
+      end
+
+      def highlight(attribute)
+        _data["highlight"][attribute].first
+      end
+
+      def highlight?(attribute)
+        _data.key?("highlight") && _data["highlight"].key?(attribute)
       end
     end
   end

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -33,7 +33,8 @@ describe Chewy::Query do
     specify { expect(subject.first._data).to be_a Hash }
     specify { expect(subject.limit(6).count).to eq(6) }
     specify { expect(subject.offset(6).count).to eq(3) }
-    specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name).to eq('<em>Name3</em>') }
+    specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name).to eq('Name3') }
+    specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlight).to eq('<em>Name3</em>') }
     specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first._data['_source']['name']).to eq('Name3') }
     specify { expect(subject.types(:product).count).to eq(3) }
     specify { expect(subject.types(:product, :country).count).to eq(6) }

--- a/spec/chewy/type/wrapper_spec.rb
+++ b/spec/chewy/type/wrapper_spec.rb
@@ -10,12 +10,37 @@ describe Chewy::Type::Wrapper do
 
   let(:city_type) { CitiesIndex::City }
 
-  subject { city_type.new(name: 'Martin', age: 42) }
+  subject(:city) { city_type.new(name: 'Martin', age: 42) }
 
-  it { is_expected.to respond_to :name }
-  it { is_expected.to respond_to :age }
-  its(:name) { should == 'Martin' }
-  its(:age) { should == 42 }
+  it do
+    is_expected.to respond_to(:name)
+      .and respond_to(:age)
+      .and have_attributes(
+        name: 'Martin',
+        age: 42
+      )
+  end
+
+  it { expect { city.population }.to raise_error(NoMethodError) }
+
+  context 'highlight' do
+    subject(:city) do
+      city_type.new(name: 'Martin', age: 42)
+        .tap do |city|
+          city._data = {
+            'highlight' => { 'name' => ['<b>Mar</b>tin'] }
+          }
+        end
+    end
+
+    it do
+      is_expected.to respond_to(:name_highlight)
+        .and have_attributes(
+          name: 'Martin',
+          name_highlight: '<b>Mar</b>tin'
+        )
+    end
+  end
 
   describe '#==' do
     specify { expect(city_type.new(id: 42)).to eq(city_type.new(id: 42)) }


### PR DESCRIPTION
It seems unexpected to get highlighted attribute calling its name on `Chewy::Type` object:
```ruby
object = Chewy::Query.new.query(match: {name: 'name'})
  .highlight(fields: {name: {}}).first
object.name # => '<em>Name</em>'
```
Getting original attribute is really hard: `object._data['_source']['name']`

Main idea here is to reimplement method_missing for `Chewy::Type` so:
- `object.name` will return raw name attribute value (one stored in index)
- `object.name_highlight` will return highlighted name attribute
- `object.name_highlight` will response only when highlighting was turned on in query.