### PR TITLE
Refactor/extract method on prefix

### DIFF
--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -30,12 +30,12 @@ module Chewy
     #
     def self.index_name(suggest = nil)
       if suggest
-        @index_name = build_index_name(suggest, prefix: prefix)
+        @index_name = build_index_name(suggest, prefix: default_prefix)
       else
         @index_name ||= begin
           build_index_name(
             name.sub(/Index\Z/, '').demodulize.underscore,
-            prefix: Chewy.configuration[:prefix]
+            prefix: default_prefix 
           ) if name
         end
       end
@@ -44,7 +44,7 @@ module Chewy
 
     # Prefix to use 
     #
-    def self.prefix
+    def self.default_prefix
       Chewy.configuration[:prefix]
     end
 

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -30,7 +30,7 @@ module Chewy
     #
     def self.index_name(suggest = nil)
       if suggest
-        @index_name = build_index_name(suggest, prefix: Chewy.configuration[:prefix])
+        @index_name = build_index_name(suggest, prefix: prefix)
       else
         @index_name ||= begin
           build_index_name(
@@ -40,6 +40,12 @@ module Chewy
         end
       end
       @index_name or raise UndefinedIndex
+    end
+
+    # Prefix to use 
+    #
+    def self.prefix
+      Chewy.configuration[:prefix]
     end
 
     # Defines type for the index. Arguments depends on adapter used. For

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -68,9 +68,9 @@ describe Chewy::Index do
     end
   end
 
-  describe '.prefix' do
+  describe '.default_prefix' do
     before { allow(Chewy).to receive_messages(configuration: {prefix: 'testing'}) }
-    specify { expect(Class.new(Chewy::Index).prefix).to eq('testing') }
+    specify { expect(Class.new(Chewy::Index).default_prefix).to eq('testing') }
   end
 
   describe '.define_type' do

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -68,6 +68,11 @@ describe Chewy::Index do
     end
   end
 
+  describe '.prefix' do
+    before { allow(Chewy).to receive_messages(configuration: {prefix: 'testing'}) }
+    specify { expect(Class.new(Chewy::Index).prefix).to eq('testing') }
+  end
+
   describe '.define_type' do
     specify { expect(DummiesIndex.type_hash['dummy']).to eq(DummiesIndex::Dummy) }
 


### PR DESCRIPTION
There's an open issue https://github.com/toptal/chewy/issues/225 where a monkey patch is suggested in order to get Chewy working nicely in multitenant environments.

This change will make that monkey patch much smaller to implement (you would only need to override the `default_prefix` method) as well as generally reducing repetition in the code (less references to the same configuration option).

It also paves the way for more advanced prefix-calculating functionality in the future. 