### PR TITLE
Remove memoization from index name

### DIFF
--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -32,7 +32,7 @@ module Chewy
       if suggest
         @index_name = build_index_name(suggest, prefix: default_prefix)
       else
-        @index_name ||= begin
+        @index_name = begin
           build_index_name(
             name.sub(/Index\Z/, '').demodulize.underscore,
             prefix: default_prefix 

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -66,6 +66,15 @@ describe Chewy::Index do
       specify { expect(DummiesIndex.index_name).to eq('testing_dummies') }
       specify { expect(stub_index(:dummies) { index_name :users }.index_name).to eq('testing_users') }
     end
+
+    context 'dynamic index name' do
+      specify do
+        allow(Chewy).to receive_messages(configuration: {prefix: 'testing1'})
+        expect(DummiesIndex.index_name).to eq('testing1_dummies')
+        allow(Chewy).to receive_messages(configuration: {prefix: 'testing2'})
+        expect(DummiesIndex.index_name).to eq('testing2_dummies')
+      end
+    end
   end
 
   describe '.default_prefix' do


### PR DESCRIPTION
Simple change but maybe one that needs some discussion. The reason for making this change is that the value that needs to be assigned to `@index_name` may change between calls to `index_name`, such as between requests in multitenant environment. 

If for example the `default_prefix` were set to a lambda or were overridden to be something dynamic, it wouldn't be re-initialised between requests.

We can sort this out by just not memoizing that variable, however this does introduce a performance overhead (it'll re-evaluate the regex/demodulize etc. every time and will create a new variable) however I think this overhead is very minor compared to the benefit. 

If you'd prefer not to have the overhead at all I could introduce this as a configurable option (`dynamic_index_names: true` or something) but then that's maybe a step too far. 
