### PR TITLE
Fixed base field compose when hash_key is a symbol and hash_value is …

### DIFF
--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -39,10 +39,16 @@ module Chewy
             value.call(*objects.first(value.arity))
           end
         elsif object.is_a?(Hash)
-          object[name] || object[name.to_s]
+          if object.has_key?(name)
+            object[name]
+          else
+            object[name.to_s]
+          end
         else
           object.send(name)
         end
+
+
 
         result = if result.respond_to?(:to_ary)
           result.to_ary.map { |result| compose_children(result, *objects) }

--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -11,6 +11,10 @@ describe Chewy::Fields::Base do
     specify { expect(field.compose(double(value: ['hello', 'world']))).to eq({name: ['hello', 'world']}) }
 
     specify { expect(described_class.new(:name).compose(double(name: 'hello'))).to eq({name: 'hello'}) }
+    specify { expect(described_class.new(:false_value).compose({false_value: false})).to eq({false_value: false}) }
+    specify { expect(described_class.new(:true_value).compose({true_value: true})).to eq({true_value: true}) }
+    specify { expect(described_class.new(:nil_value).compose({nil_value: nil})).to eq({nil_value: nil}) }
+
 
     context 'nested fields' do
       before do
@@ -62,14 +66,14 @@ describe Chewy::Fields::Base do
 
     context 'hash values' do
       let(:field) { described_class.new(:name, type: 'object') }
-      let(:object) { double(name: { key1: 'value1', key2: 'value2' }) }
+      let(:object) { double(name: { key1: 'value1', key2: 'value2'}) }
 
       before do
         field.children.push(described_class.new(:key1, value: ->(h){ h[:key1] }))
         field.children.push(described_class.new(:key2, value: ->(h){ h[:key2] }))
       end
 
-      specify{ expect(field.compose(object)).to eq({ name: { 'key1' => 'value1', 'key2' => 'value2' } }) }
+      specify{ expect(field.compose(object)).to eq({ name: { 'key1' => 'value1', 'key2' => 'value2'} }) }
     end
   end
 


### PR DESCRIPTION
An object field whose value is an hash with symbol keys and one of them contains a `false` value. The corresponding field will be indexed with `null` instead of `false`

example :
```ruby
field :person, value: (task, crutch) -> {crutch.person[task.id]} do
  field :name, type:string
  field :is_male, type: boolean
end
```
Let's say that `crutch.person[task.id]` would return 
```ruby
{
  name: 'Jane Doe'
  is_male: false
}
```

`is_male` would be index has `null` instead of `false`