### PR TITLE
Allow worker strategies to receive import options

### DIFF
--- a/lib/chewy/strategy/active_job.rb
+++ b/lib/chewy/strategy/active_job.rb
@@ -13,8 +13,8 @@ module Chewy
       class Worker < ::ActiveJob::Base
         queue_as :chewy
 
-        def perform(type, ids)
-          type.constantize.import!(ids)
+        def perform(type, ids, options = {})
+          type.constantize.import!(ids, options)
         end
       end
 

--- a/lib/chewy/strategy/resque.rb
+++ b/lib/chewy/strategy/resque.rb
@@ -13,8 +13,8 @@ module Chewy
       class Worker
         @queue = :chewy
 
-        def self.perform(type, ids)
-          type.constantize.import!(ids)
+        def self.perform(type, ids, options = {})
+          type.constantize.import!(ids, options)
         end
       end
 

--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -13,8 +13,8 @@ module Chewy
       class Worker
         include ::Sidekiq::Worker
 
-        def perform(type, ids)
-          type.constantize.import!(ids)
+        def perform(type, ids, options = {})
+          type.constantize.import!(ids, options)
         end
       end
 

--- a/spec/chewy/strategy/active_job_spec.rb
+++ b/spec/chewy/strategy/active_job_spec.rb
@@ -45,5 +45,10 @@ if defined?(::ActiveJob)
         .to update_index(CitiesIndex::City, strategy: :active_job)
         .and_reindex(city, other_city)
     end
+
+    specify do
+      expect(CitiesIndex::City).to receive(:import!).with([city.id, other_city.id], {suffix: '201601'})
+      Chewy::Strategy::ActiveJob::Worker.new.perform("CitiesIndex::City", [city.id, other_city.id], suffix: '201601')
+    end
   end
 end

--- a/spec/chewy/strategy/resque_spec.rb
+++ b/spec/chewy/strategy/resque_spec.rb
@@ -31,5 +31,10 @@ if defined?(::Resque)
           .and_reindex(city, other_city)
       end
     end
+
+    specify do
+      expect(CitiesIndex::City).to receive(:import!).with([city.id, other_city.id], {suffix: '201601'})
+      Chewy::Strategy::Resque::Worker.perform("CitiesIndex::City", [city.id, other_city.id], suffix: '201601')
+    end
   end
 end

--- a/spec/chewy/strategy/sidekiq_spec.rb
+++ b/spec/chewy/strategy/sidekiq_spec.rb
@@ -31,5 +31,10 @@ if defined?(::Sidekiq)
           .and_reindex(city, other_city)
       end
     end
+
+    specify do
+      expect(CitiesIndex::City).to receive(:import!).with([city.id, other_city.id], {suffix: '201601'})
+      Chewy::Strategy::Sidekiq::Worker.new.perform("CitiesIndex::City", [city.id, other_city.id], suffix: '201601')
+    end
   end
 end


### PR DESCRIPTION
This pull allows the Sidekiq, Resque, and ActiveJob strategy workers to be called with an options hash to pass to `#import!`. It makes it easy to completely rebuild an index with a different suffix in the background.