### PR TITLE
Type#method_missing calls super

### DIFF
--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -53,6 +53,8 @@ module Chewy
           all.scoping { index.public_send(method, *args, &block) }
         end
         send(method, *args, &block)
+      else
+        super
       end
     end
 

--- a/spec/chewy/type_spec.rb
+++ b/spec/chewy/type_spec.rb
@@ -19,5 +19,6 @@ describe Chewy::Type do
 
     specify { expect(described_class.scopes).to eq([]) }
     specify { expect(PlacesIndex::City.scopes).to match_array([:by_rating, :by_name]) }
+    specify { expect { PlacesIndex::City.non_existing_method_call }.to raise_error(NoMethodError) }
   end
 end


### PR DESCRIPTION
Earlier implementation returned nil on unknown method calls, which would make debugging much harder.