### PR TITLE
Use scoped subscription to ActiveSupport::Notifications

### DIFF
--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -2,8 +2,8 @@ module Chewy
   module RakeHelper
     class << self
 
-      def subscribe_task_stats!
-        ActiveSupport::Notifications.subscribe('import_objects.chewy') do |name, start, finish, id, payload|
+      def subscribed_task_stats(&block)
+        callback = ->(name, start, finish, id, payload) do
           duration = (finish - start).round(2)
           puts "  Imported #{payload[:type]} for #{duration}s, documents total: #{payload[:import].try(:[], :index).to_i}"
           payload[:errors].each do |action, errors|
@@ -13,6 +13,9 @@ module Chewy
               puts "        on #{documents.count} documents: #{documents}"
             end
           end if payload[:errors]
+        end
+        ActiveSupport::Notifications.subscribed(callback, 'import_objects.chewy') do
+          yield
         end
       end
 

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -3,39 +3,43 @@ require 'chewy/rake_helper'
 namespace :chewy do
   desc 'Destroy, recreate and import data to specified index'
   task :reset, [:index] => :environment do |task, args|
-    Chewy::RakeHelper.subscribe_task_stats!
+    Chewy::RakeHelper.subscribed_task_stats do
 
-    if args[:index].present?
-      Chewy::RakeHelper.reset_index(args[:index])
-    else
-      Chewy::RakeHelper.reset_all
+      if args[:index].present?
+        Chewy::RakeHelper.reset_index(args[:index])
+      else
+        Chewy::RakeHelper.reset_all
+      end
     end
   end
 
   namespace :reset do
     desc 'Destroy, recreate and import data for all found indexes'
     task all: :environment do
-      Chewy::RakeHelper.subscribe_task_stats!
-      Chewy::RakeHelper.reset_all
+      Chewy::RakeHelper.subscribed_task_stats do
+        Chewy::RakeHelper.reset_all
+      end
     end
   end
 
   desc 'Updates data specified index'
   task :update, [:index] => :environment do |task, args|
-    Chewy::RakeHelper.subscribe_task_stats!
+    Chewy::RakeHelper.subscribed_task_stats do
 
-    if args[:index].present?
-      Chewy::RakeHelper.update_index(args[:index])
-    else
-      Chewy::RakeHelper.update_all
+      if args[:index].present?
+        Chewy::RakeHelper.update_index(args[:index])
+      else
+        Chewy::RakeHelper.update_all
+      end
     end
   end
 
   namespace :update do
     desc 'Updates data for all found indexes'
     task all: :environment do
-      Chewy::RakeHelper.subscribe_task_stats!
-      Chewy::RakeHelper.update_all
+      Chewy::RakeHelper.subscribed_task_stats do
+        Chewy::RakeHelper.update_all
+      end
     end
   end
 end


### PR DESCRIPTION
When chewy tasks are invoked multiple times from the same environment - their stats are printed as many times as they were invoked. Easiest way to see it is with `rake chewy:update[model1] chewy:reset[model2]`.
This PR makes subscriptions scoped to the task block only.