### PR TITLE
Remove redundant preloading from the example describing Crutches™ Technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Then you can replace Rails associations with Chewy Crutches™ technology:
 
 ```ruby
 class ProductsIndex < Chewy::Index
-  define_type Product.includes(:categories) do
+  define_type Product do
     crutch :categories do |collection| # collection here is a current batch of products
       # data is fetched with a lightweight query without objects initialization
       data = ProductCategory.joins(:category).where(product_id: collection.map(&:id)).pluck(:product_id, 'categories.name')


### PR DESCRIPTION
I might be wrong here, but it seems that it is not really necessary because we use Advanced Crutches™ Technology to load category names. Please correct me if I'm missing something.
