### PR TITLE
Sanitize Elasticsearch::Client config

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -123,8 +123,10 @@ module Chewy
     #
     def client
       Thread.current[:chewy_client] ||= begin
-        block = configuration[:transport_options].try { |c| c[:proc] }
-        ::Elasticsearch::Client.new(configuration, &block)
+        client_configuration = configuration.deep_dup
+        client_configuration.delete(:prefix) # used by Chewy, not relevant to Elasticsearch::Client
+        block = client_configuration[:transport_options].try(:delete, :proc)
+        ::Elasticsearch::Client.new(client_configuration, &block)
       end
     end
 


### PR DESCRIPTION
This avoids passing invalid config values to Elasticsearch::Client.new by stripping `prefix` and `transport_options[proc]` from the config hash.

Fixes #333