### PR TITLE
Allow set import params for rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,11 @@ rake chewy:update[users] # updates UsersIndex only
 
 `rake chewy:reset` performs zero-downtime reindexing as described [here](https://www.elastic.co/blog/changing-mapping-with-zero-downtime). So basically rake task creates a new index with uniq suffix and then simply aliases it to the common index name. The previous index is deleted afterwards (see `Chewy::Index.reset!` for more details).
 
+You can specify batch size for import from console using environment variable.
+
+```bash
+CHEWY_BATCH_SIZE=500 rake chewy:reset
+```
 
 ### Rspec integration
 

--- a/README.md
+++ b/README.md
@@ -920,9 +920,9 @@ avg_johns_rating = all_johns.aggs
 ```
 
 It is possible to run into collisions between named aggregations. This occurs when there is more than one aggregation
- with the same name. To explicitly reference an aggregation you provide a string to the #aggs method of the form: 
+ with the same name. To explicitly reference an aggregation you provide a string to the #aggs method of the form:
  `index_name#document_type.aggregation_name`
- 
+
 Consider this example where there are two separate aggregations named `avg_rating`
 
 ```ruby
@@ -949,7 +949,7 @@ end
 
 all_docs = UsersIndex.filter {match_all}.aggs("users#user.avg_rating")
 all_docs.aggs
-# => {"users#user.avg_rating"=>{"value"=>3.5}} 
+# => {"users#user.avg_rating"=>{"value"=>3.5}}
 ```
 
 ### Script fields

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -160,10 +160,15 @@ module Chewy
         #
         #   UsersIndex.reset! Time.now.to_i
         #
-        def reset! suffix = nil
+        # Import params can be provided as options:
+        #
+        #   UsersIndex.reset! Time.now.to_i, batch_size: 500   # import batch size
+        #   UsersIndex.reset! Time.now.to_i, refresh: false    # to disable index refreshing after import
+        #
+        def reset! suffix = nil, params = {}
           if suffix.present? && (indexes = self.indexes).present?
             create! suffix, alias: false
-            result = import suffix: suffix
+            result = import params.merge(suffix: suffix)
             client.indices.update_aliases body: {actions: [
               *indexes.map do |index|
                 {remove: {index: index, alias: index_name}}

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -19,6 +19,12 @@ module Chewy
         end
       end
 
+      def import_params
+        {}.tap do |params|
+          params[:batch_size] = ENV['CHEWY_BATCH_SIZE'].to_i if ENV['CHEWY_BATCH_SIZE']
+        end
+      end
+
       def eager_load_chewy!
         dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths['app/chewy'] }.compact.map(&:existent).flatten.uniq
 
@@ -37,7 +43,7 @@ module Chewy
       def reset_index index
         index = normalize_index(index)
         puts "Resetting #{index}"
-        index.reset! (Time.now.to_f * 1000).round
+        index.reset! (Time.now.to_f * 1000).round, import_params
       end
 
       # Performs zero downtime reindexing of all documents across all indices.
@@ -50,7 +56,7 @@ module Chewy
         index = normalize_index(index)
         puts "Updating #{index}"
         if index.exists?
-          index.import
+          index.import import_params
         else
           puts "Index `#{index.index_name}` does not exists. Use rake chewy:reset[#{index.index_name}] to create and update it."
         end

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -389,6 +389,13 @@ describe Chewy::Index::Actions do
         specify { expect(CitiesIndex.indexes).to eq([]) }
         specify { expect(Chewy.client.indices.exists(index: 'cities_2013')).to eq(false) }
       end
+
+      context do
+        specify {
+          expect(CitiesIndex::City).to receive(:import).with(suffix: '2014', batch_size: 500)
+          CitiesIndex.reset! '2014', batch_size: 500
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
In certain cases on batch import while resetting takes so much time (due slow bulk entry generation) that items from batch can be updated from a different source (like a web server). Tuning this parameter allows making single batch import fast enough that example situation never happen.

For a sake of symmetry, this change also allows you to set `refresh` param for import from a console.

@pyromaniac What do you think?
