### PR TITLE
Add type specific settings

### DIFF
--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -12,6 +12,8 @@ require 'chewy/type/adapter/sequel'
 
 module Chewy
   class Type
+    IMPORT_OPTIONS_KEYS = %i[batch_size]
+
     include Search
     include Mapping
     include Wrapper
@@ -51,6 +53,7 @@ module Chewy
     end
 
     def self.default_import_options(params)
+      params.assert_valid_keys(IMPORT_OPTIONS_KEYS)
       self._default_import_options = _default_import_options.merge(params)
     end
 

--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -22,6 +22,9 @@ module Chewy
 
     singleton_class.delegate :index_name, :client, to: :index
 
+    class_attribute :_default_import_options
+    self._default_import_options = {}
+
     # Chewy index current type belongs to. Defined inside `Chewy.create_type`
     #
     def self.index
@@ -45,6 +48,10 @@ module Chewy
     #
     def self.scopes
       public_methods - Chewy::Type.public_methods
+    end
+
+    def self.default_import_options(params)
+      self._default_import_options = _default_import_options.merge(params)
     end
 
     def self.method_missing(method, *args, &block)

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -20,6 +20,7 @@ module Chewy
         def import *args
           import_options = args.extract_options!
           bulk_options = import_options.reject { |k, v| ![:refresh, :suffix].include?(k) }.reverse_merge!(refresh: true)
+          import_options.reverse_merge! self._default_import_options
 
           index.create!(bulk_options.slice(:suffix)) unless index.exists?
 

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -355,6 +355,17 @@ describe Chewy::Type::Import do
 
     end
 
+    context 'default_import_options is set' do
+      before do
+        CitiesIndex::City.default_import_options(batch_size: 500)
+      end
+
+      specify {
+        expect(CitiesIndex::City.adapter).to receive(:import).with(batch_size: 500)
+        CitiesIndex::City.import
+      }
+    end
+
     xcontext 'performance' do
       let!(:cities) do
         1000.times.map do |i|

--- a/spec/chewy/type_spec.rb
+++ b/spec/chewy/type_spec.rb
@@ -18,9 +18,11 @@ describe Chewy::Type do
     end
 
     specify { expect(described_class.scopes).to eq([]) }
-    specify { expect(PlacesIndex::City._default_import_options).to eq({}) }
     specify { expect(PlacesIndex::City.scopes).to match_array([:by_rating, :by_name]) }
     specify { expect { PlacesIndex::City.non_existing_method_call }.to raise_error(NoMethodError) }
+
+    specify { expect(PlacesIndex::City._default_import_options).to eq({}) }
+    specify { expect { PlacesIndex::City.default_import_options(invalid_option: "Yeah!") }.to raise_error(ArgumentError) }
 
     context 'default_import_options is set' do
       before { PlacesIndex::City.default_import_options(batch_size: 500) }

--- a/spec/chewy/type_spec.rb
+++ b/spec/chewy/type_spec.rb
@@ -18,7 +18,14 @@ describe Chewy::Type do
     end
 
     specify { expect(described_class.scopes).to eq([]) }
+    specify { expect(PlacesIndex::City._default_import_options).to eq({}) }
     specify { expect(PlacesIndex::City.scopes).to match_array([:by_rating, :by_name]) }
     specify { expect { PlacesIndex::City.non_existing_method_call }.to raise_error(NoMethodError) }
+
+    context 'default_import_options is set' do
+      before { PlacesIndex::City.default_import_options(batch_size: 500) }
+
+      specify { expect(PlacesIndex::City._default_import_options).to eq(batch_size: 500) }
+    end
   end
 end


### PR DESCRIPTION
As mentioned in https://github.com/toptal/chewy/pull/340 adding per type settings for import options would be a nice idea. It allows to tune batch size for each defined type specifically.

@pyromaniac What do you think about it?