### PR TITLE
Fixed invalid multibyte char error

### DIFF
--- a/lib/chewy/type/witchcraft.rb
+++ b/lib/chewy/type/witchcraft.rb
@@ -22,9 +22,9 @@ module Chewy
 
         def check_requirements!
           messages = []
-          messages << "MethodSource gem is required for the Witchcraft™, please add `gem 'method_source'` to your Gemfile" unless Proc.method_defined?(:source)
-          messages << "Parser gem is required for the Witchcraft™, please add `gem 'parser'` to your Gemfile" unless '::Parser'.safe_constantize
-          messages << "Unparser gem is required for the Witchcraft™, please add `gem 'unparser'` to your Gemfile" unless '::Unparser'.safe_constantize
+          messages << "MethodSource gem is required for the Witchcraft, please add `gem 'method_source'` to your Gemfile" unless Proc.method_defined?(:source)
+          messages << "Parser gem is required for the Witchcraft, please add `gem 'parser'` to your Gemfile" unless '::Parser'.safe_constantize
+          messages << "Unparser gem is required for the Witchcraft, please add `gem 'unparser'` to your Gemfile" unless '::Unparser'.safe_constantize
           messages = messages.join("\n")
 
           raise messages if messages.present?


### PR DESCRIPTION
This log lines caused SyntaxError: /usr/local/rvm/gems/jruby-1.7.22/gems/chewy-0.8.4/lib/chewy/type/witchcraft.rb:25: invalid multibyte char (US-ASCII)
