### PR TITLE
Reset import opts

### DIFF
--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -161,7 +161,7 @@ module Chewy
         #   UsersIndex.reset! Time.now.to_i
         #
         def reset! suffix = nil, opts = {}
-          import_opts = {suffix: suffix}.merge(opts[:import_opts])
+          import_opts = {suffix: suffix}.merge(opts[:import_opts] || {})
 
           if suffix.present? && (indexes = self.indexes).present?
             create! suffix, alias: false

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -161,9 +161,10 @@ module Chewy
         #   UsersIndex.reset! Time.now.to_i
         #
         def reset! suffix = nil, opts = {}
+          import_opts = {suffix: suffix}.merge(opts[:import_opts])
+
           if suffix.present? && (indexes = self.indexes).present?
             create! suffix, alias: false
-            import_opts = {suffix: suffix}.merge(opts[:import_opts])
             result = import import_opts
             client.indices.update_aliases body: {actions: [
               *indexes.map do |index|
@@ -175,7 +176,7 @@ module Chewy
             result
           else
             purge! suffix
-            import
+            import import_ops
           end
         end
       end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -176,7 +176,7 @@ module Chewy
             result
           else
             purge! suffix
-            import import_ops
+            import import_opts
           end
         end
       end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -160,10 +160,11 @@ module Chewy
         #
         #   UsersIndex.reset! Time.now.to_i
         #
-        def reset! suffix = nil
+        def reset! suffix = nil, opts = {}
           if suffix.present? && (indexes = self.indexes).present?
             create! suffix, alias: false
-            result = import suffix: suffix
+            import_opts = {suffix: suffix}.merge(opts[:import_opts])
+            result = import import_opts
             client.indices.update_aliases body: {actions: [
               *indexes.map do |index|
                 {remove: {index: index, alias: index_name}}


### PR DESCRIPTION
Allows the `#reset!` method to accept an options hash, specifically to allow the `#import` method to implement those options. This fork was originally created to allow passing in the `batch_size` option to the inner `#import` method.