### PR TITLE
Add method Index.type(type_name) which raises UndefinedType on unknown type_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ You can access index-defined types with the following API:
 ```ruby
 UsersIndex::User # => UsersIndex::User
 UsersIndex.type_hash['user'] # => UsersIndex::User
+UsersIndex.type('user') # => UsersIndex::User
+UsersIndex.type('foo') # => raises error UndefinedType("Unknown type in UsersIndex: foo")
 UsersIndex.types # => [UsersIndex::User]
 UsersIndex.type_names # => ['user']
 ```

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -123,6 +123,14 @@ module Chewy
       type_hash.keys
     end
 
+    # Returns named type:
+    #
+    #    UserIndex.type('admin') # => UsersIndex::Admin
+    #
+    def self.type(type_name)
+      type_hash.fetch(type_name) { raise UndefinedType, "Unknown type in #{name}: #{type_name}" }
+    end
+
     # Used as a part of index definition DSL. Defines settings:
     #
     #   class UsersIndex < Chewy::Index

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -1000,7 +1000,7 @@ module Chewy
           .merge!(_score: hit['_score'])
           .merge!(_explanation: hit['_explanation'])
 
-        wrapper = _derive_index(hit['_index']).type_hash[hit['_type']].new attributes
+        wrapper = _derive_index(hit['_index']).type(hit['_type']).new(attributes)
         wrapper._data = hit
         wrapper
       end

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -136,6 +136,11 @@ describe Chewy::Index do
     specify { expect(DummiesIndex.type_hash['dummy'].type_name).to eq('dummy') }
   end
 
+  describe '.type' do
+    specify { expect(DummiesIndex.type('dummy')).to eq(DummiesIndex::Dummy) }
+    specify { expect { DummiesIndex.type('not-the-dummy') }.to raise_error(Chewy::UndefinedType) }
+  end
+
   specify { expect(DummiesIndex.type_names).to eq(DummiesIndex.type_hash.keys) }
 
   describe '.types' do


### PR DESCRIPTION
**Current behavior:**

undefined method `new' for nil:NilClass /usr/local/lib/ruby/gems/2.3.0/bundler/gems/chewy-27a71cc1ed55/lib/chewy/query.rb:1003:in `block in _results'

**New behavior:**

Raises `UndefinedType` with what Index was missing which Type.

```ruby
UsersIndex.type('user') # => UsersIndex::User
UsersIndex.type('foo') # => raises error UndefinedType("Unknown type in UsersIndex: foo")
```