### PR TITLE
Fixing an encoding issue for ruby <= 1.9.x

### DIFF
--- a/lib/chewy/type/witchcraft.rb
+++ b/lib/chewy/type/witchcraft.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 def try_require lib
   require lib
 rescue LoadError


### PR DESCRIPTION
Hey,

just ran into this issue on a 1.9.3 platform. On this and earlier versions you'll get a acii error since the tm character is not part of the charset.

Cheers