### PR TITLE
Append newline after each bulk request

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -83,7 +83,7 @@ module Chewy
               else
                 result[-1] = [result[-1], entry].delete_if(&:blank?).join("\n")
               end
-            end
+            end.map { |entry| entry + "\n" }
           else
             [body]
           end

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -70,6 +70,10 @@ describe Chewy::Type::Import do
     end
 
     context ':bulk_size' do
+      specify { expect(city.import(dummy_cities.first, bulk_size: 1.2.kilobyte)).to eq(true) }
+      specify { expect(city.import(dummy_cities, bulk_size: 1.2.kilobyte)).to eq(true) }
+      specify { expect { city.import(dummy_cities, bulk_size: 1.2.kilobyte) }.to update_index(city).and_reindex(dummy_cities) }
+
       specify do
         dummy_cities.first.destroy
 
@@ -78,8 +82,8 @@ describe Chewy::Type::Import do
 
         city.import dummy_cities.map(&:id), bulk_size: 1.2.kilobyte
         expect(imported.flatten).to match_array([
-          %Q({"delete":{"_id":1}}),
-          %Q({"index":{"_id":2}}\n{"name":"name1"}\n{"index":{"_id":3}}\n{"name":"name2"})
+          %Q({"delete":{"_id":1}}\n),
+          %Q({"index":{"_id":2}}\n{"name":"name1"}\n{"index":{"_id":3}}\n{"name":"name2"}\n)
         ])
       end
 
@@ -94,9 +98,9 @@ describe Chewy::Type::Import do
 
           city.import dummy_cities.map(&:id), bulk_size: 1.2.kilobyte
           expect(imported.flatten).to match_array([
-            %Q({"delete":{"_id":1}}),
-            %Q({"index":{"_id":2}}\n{"name":"#{'name1' * 20}"}),
-            %Q({"index":{"_id":3}}\n{"name":"#{'name2' * 20}"})
+            %Q({"delete":{"_id":1}}\n),
+            %Q({"index":{"_id":2}}\n{"name":"#{'name1' * 20}"}\n),
+            %Q({"index":{"_id":3}}\n{"name":"#{'name2' * 20}"}\n)
           ])
         end
 


### PR DESCRIPTION
Added a test at `spec/chewy/type/import_spec.rb:73` which fails as following:
```
  1) Chewy::Type::Import.import :bulk_size 
     Failure/Error: result = client.bulk options.merge(header).merge(body: body)
     
     Elasticsearch::Transport::Transport::Errors::BadRequest:
       [400] {"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: no requests added;"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: no requests added;"},"status":400}
```
Looks like to be known issue - need a newline at the end of bulk entry, see
https://discuss.elastic.co/t/elastic-search-bulk-post-testing/24065/4
http://stackoverflow.com/a/22997612
This PR adds missing newline so test passes.