### PR TITLE
Add support for raw_import flag

### DIFF
--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -13,7 +13,7 @@ require 'chewy/type/adapter/sequel'
 
 module Chewy
   class Type
-    IMPORT_OPTIONS_KEYS = [:batch_size, :bulk_size, :refresh, :consistency, :replication]
+    IMPORT_OPTIONS_KEYS = [:batch_size, :bulk_size, :refresh, :consistency, :replication, :raw_import]
 
     include Search
     include Mapping

--- a/spec/chewy/type/adapter/active_record_spec.rb
+++ b/spec/chewy/type/adapter/active_record_spec.rb
@@ -104,6 +104,27 @@ describe Chewy::Type::Adapter::ActiveRecord, :active_record do
 
       specify { expect(import(cities.first, nil)).to eq([{index: [cities.first]}]) }
       specify { expect(import(cities.first.id, nil)).to eq([{index: [cities.first]}]) }
+
+      context 'raw_import' do
+        let(:probe) { double }
+        let(:converter) { ->(raw_hash) { probe.call(raw_hash) } }
+        let(:moscow) { OpenStruct.new(id: 1, name: 'Moscow') }
+        let(:warsaw) { OpenStruct.new(id: 2, name: 'Warsaw') }
+        let(:madrid) { OpenStruct.new(id: 3, name: 'Madrid') }
+        before do
+          @one, @two, @three = City.all.to_a
+        end
+
+        it 'uses the raw import converter to make objects out of raw hashes from the database' do
+          expect(City).not_to receive(:new)
+
+          expect(probe).to receive(:call).with(a_hash_including('id' => @one.id, 'name' => @one.name)).and_return(moscow)
+          expect(probe).to receive(:call).with(a_hash_including('id' => @two.id, 'name' => @one.name)).and_return(warsaw)
+          expect(probe).to receive(:call).with(a_hash_including('id' => @three.id, 'name' => @three.name)).and_return(madrid)
+
+          expect(import(City.where(nil), raw_import: converter)).to eq([{index: [moscow, warsaw, madrid]}])
+        end
+      end
     end
 
     context 'additional delete conitions' do

--- a/spec/chewy/type_spec.rb
+++ b/spec/chewy/type_spec.rb
@@ -25,9 +25,10 @@ describe Chewy::Type do
     specify { expect { PlacesIndex::City.default_import_options(invalid_option: "Yeah!") }.to raise_error(ArgumentError) }
 
     context 'default_import_options is set' do
-      before { PlacesIndex::City.default_import_options(batch_size: 500) }
+      let(:converter) { -> {} }
+      before { PlacesIndex::City.default_import_options(batch_size: 500, raw_import: converter) }
 
-      specify { expect(PlacesIndex::City._default_import_options).to eq(batch_size: 500) }
+      specify { expect(PlacesIndex::City._default_import_options).to eq(batch_size: 500, raw_import: converter) }
     end
   end
 end


### PR DESCRIPTION
A new `raw_import` option was added. Basically, it allows to avoid unnecessary serialization->deserialization cycles when it matters. Often, a lot of time is spent on creating AR objects, typecasting fields, etc. But eventually, it all gets converted back to strings. So why waste resources on unnecessary conversions. Raw Import is added just for this purpose. On one of our indexes, using this feature shanked index reset time from 7.5 minutes to 4.5 minutes.

The details on how to use this feature can be found [in the updated documentation](https://github.com/toptal/chewy/pull/375/files#diff-04c6e90faac2675aa89e2176d2eec7d8R412).