### PR TITLE
Refactor/remove memoization of index name prefix

### DIFF
--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -29,11 +29,8 @@ module Chewy
     #   UsersIndex.index_name # => 'dudes'
     #
     def self.index_name(suggest = nil)
-      if suggest
-        @index_name_stem = suggest
-      end
-      @index_name = build_index_name(index_name_stem, prefix: default_prefix)
-      @index_name or raise UndefinedIndex
+      index_name = build_index_name(index_name_stem(suggest), prefix: default_prefix)
+      index_name or raise UndefinedIndex
     end
 
     # Prefix to use
@@ -174,7 +171,11 @@ module Chewy
       [settings_hash, mappings_hash].inject(:merge)
     end
 
-    def self.index_name_stem
+    # set or compute index_name_stem
+    def self.index_name_stem(suggest = nil)
+      if suggest
+        @index_name_stem = suggest
+      end
       @index_name_stem || name.sub(/Index\Z/, '').demodulize.underscore
     end
   end

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -164,7 +164,7 @@ module Chewy
 
     def self.build_index_name *args
       options = args.extract_options!
-      [options[:prefix], args.first || index_name, options[:suffix]].reject(&:blank?).join(?_)
+      [options[:prefix], args.first, options[:suffix]].reject(&:blank?).join(?_)
     end
 
     def self.settings_hash

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -155,7 +155,7 @@ module Chewy
 
     def self.build_index_name *args
       options = args.extract_options!
-      [options[:prefix], args.first, options[:suffix]].reject(&:blank?).join(?_)
+      [options[:prefix], args.first || index_name_stem, options[:suffix]].reject(&:blank?).join(?_)
     end
 
     def self.settings_hash
@@ -175,8 +175,11 @@ module Chewy
     def self.index_name_stem(suggest = nil)
       if suggest
         @index_name_stem = suggest
+      elsif name
+        @index_name_stem || name.sub(/Index\Z/, '').demodulize.underscore
+      else
+        @index_name_stem or raise UndefinedIndex
       end
-      @index_name_stem || name.sub(/Index\Z/, '').demodulize.underscore
     end
   end
 end

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -30,15 +30,9 @@ module Chewy
     #
     def self.index_name(suggest = nil)
       if suggest
-        @index_name = build_index_name(suggest, prefix: default_prefix)
-      else
-        @index_name ||= begin
-          build_index_name(
-            name.sub(/Index\Z/, '').demodulize.underscore,
-            prefix: default_prefix
-          ) if name
-        end
+        @index_name_stem = suggest
       end
+      @index_name = build_index_name(index_name_stem, prefix: default_prefix)
       @index_name or raise UndefinedIndex
     end
 
@@ -178,6 +172,10 @@ module Chewy
 
     def self.index_params
       [settings_hash, mappings_hash].inject(:merge)
+    end
+
+    def self.index_name_stem
+      @index_name_stem || name.sub(/Index\Z/, '').demodulize.underscore
     end
   end
 end

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -66,6 +66,15 @@ describe Chewy::Index do
       specify { expect(DummiesIndex.index_name).to eq('testing_dummies') }
       specify { expect(stub_index(:dummies) { index_name :users }.index_name).to eq('testing_users') }
     end
+
+    context do
+      before { Chewy.settings = {prefix: 'tenant1'} }
+      specify {
+        expect {
+          Chewy.settings = {prefix: 'tenant2'}
+        }.to change { DummiesIndex.index_name }.from('tenant1_dummies').to('tenant2_dummies')
+      }
+    end
   end
 
   describe '.default_prefix' do


### PR DESCRIPTION
There is an open pull request #314 concerning the issue that for multitenant applications the index prefix needs to be set dynamically (#225) which is currently not possible since the index name is memoized. I think there has been some misunderstanding concerning the point of the memoization which is not performance related, but rather a result of the fact that `index_name` is both a getter and setter (unfortunately) and it should be memoized if set explicitly.

This behavior is preserved in the changes I propose by saving the `index_name_stem` when it is set while allowing the prefix to be reevaluated every time `index_name` is accessed.
