### PR TITLE
attribute_highlight should return an array of highlights

### DIFF
--- a/lib/chewy/type/wrapper.rb
+++ b/lib/chewy/type/wrapper.rb
@@ -42,7 +42,7 @@ module Chewy
       end
 
       def highlight(attribute)
-        _data["highlight"][attribute].first
+        _data["highlight"][attribute]
       end
 
       def highlight?(attribute)

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -34,7 +34,7 @@ describe Chewy::Query do
     specify { expect(subject.limit(6).count).to eq(6) }
     specify { expect(subject.offset(6).count).to eq(3) }
     specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name).to eq('Name3') }
-    specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlight).to eq('<em>Name3</em>') }
+    specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlight).to eq(['<em>Name3</em>']) }
     specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first._data['_source']['name']).to eq('Name3') }
     specify { expect(subject.types(:product).count).to eq(3) }
     specify { expect(subject.types(:product, :country).count).to eq(6) }

--- a/spec/chewy/type/wrapper_spec.rb
+++ b/spec/chewy/type/wrapper_spec.rb
@@ -37,7 +37,7 @@ describe Chewy::Type::Wrapper do
       is_expected.to respond_to(:name_highlight)
         .and have_attributes(
           name: 'Martin',
-          name_highlight: '<b>Mar</b>tin'
+          name_highlight: ['<b>Mar</b>tin']
         )
     end
   end


### PR DESCRIPTION
Highlight of an attribute, for example `title_attribute`, should return an array rather than the first element of the array.
