### PR TITLE
Fix routing_missing_exception on delete with parent missing

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -121,7 +121,8 @@ module Chewy
 
           if root_object.parent_id
             existing_object = entry[:_id].present? && indexed_objects && indexed_objects[entry[:_id].to_s]
-            entry.merge!(parent: existing_object[:parent]) if existing_object
+            return [] unless existing_object
+            entry.merge!(parent: existing_object[:parent])
           end
 
           [{ delete: entry }]

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -341,6 +341,13 @@ describe Chewy::Type::Import do
 
           city.import child_city.id
         end
+
+        specify do
+          child_city.destroy
+
+          expect(city.import child_city).to eq(true)
+          expect(city.import child_city).to eq(true)
+        end
       end
     end
 


### PR DESCRIPTION
Elasticsearch 2.2+ returns error when trying to delete an object that must have parent but parent is not sent.

This occurs when object is not present, so existing_object is nil. In this case, it was not populating parent key and then causing error routing_missing_exception on Elasticsearch.

The solution is to skip delete if record does not exists.