### PR TITLE
Journaling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# gem 'activerecord'
+gem 'activerecord'
 # gem 'mongoid'
 # gem 'sequel'
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'activerecord'
+# gem 'activerecord'
 # gem 'mongoid'
 # gem 'sequel'
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Chewy is an ODM and wrapper for [the official Elasticsearch client](https://gith
   * [Crutches™ technology] (#crutches-technology)
   * [Witchcraft™ technology] (#witchcraft-technology)
   * [Raw Import] (#raw-import)
+  * [Journaling] (#journaling)
   * [Types access] (#types-access)
   * [Index manipulation] (#index-manipulation)
   * [Index update strategies] (#index-update-strategies)
@@ -478,6 +479,58 @@ end
 ```
 
 Also, you can pass `:raw_import` option to the `import` method explicitly.
+
+
+### Journaling
+
+You can record all actions that were made to the separate journal index in ElasticSearch.
+When you create/update/destroy your records, it will be saved in this special index.
+If you make something with a batch of records (e.g. during index reset) it will be saved as a one record, including primary keys of each document that was affected.
+Common journal record looks like this:
+
+```json
+{
+  "action": "index",
+  "object_id": [1, 2, 3],
+  "index_name": "...",
+  "type_name": "...",
+  "created_at": "<timestamp>"
+}
+```
+
+This feature is turned off by default.
+But you can turn it on by setting `journal` setting to `true` in `config/chewy.yml`.
+Also, you can specify journal index name. For example:
+
+```yaml
+# config/chewy.yml
+production:
+  journal: true,
+  journal_name: my_super_journal
+```
+
+Also, you can provide this option while you're importing some index:
+
+```ruby
+CityIndex.import journal: true
+```
+
+Or as a default import option for an index:
+
+```ruby
+class CityIndex
+  define_type City do
+    default_import_options journal: true
+  end
+end
+```
+
+You may be wondering why do you need it? The answer is simple: Not to lose the data.
+Imagine that:
+You reset your index in Zero Downtime manner (to separate index), and meantime somebody keeps updating the data frequently (to old index). So all these actions will be written to the journal index and you'll be able to apply them after index reset with `Chewy::Journal.apply_changes_from(Time.now - 1.hour)`.
+
+For index reset journaling is turned off even if you set `journal: true` in `config/chewy.yml` or in `default_import_options`.
+You can change it only if you pass `journal: true` parameter explicitly to `#import`.
 
 ### Types access
 

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'elasticsearch-extensions'
   spec.add_development_dependency 'resque_spec'
   spec.add_development_dependency 'rubysl', '~> 2.0' if RUBY_ENGINE == 'rbx'
+  spec.add_development_dependency 'timecop'
 
   spec.add_development_dependency 'method_source'
   if RUBY_VERSION < '2.1.0'

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -31,6 +31,7 @@ require 'chewy/index'
 require 'chewy/type'
 require 'chewy/fields/base'
 require 'chewy/fields/root'
+require 'chewy/journal'
 require 'chewy/railtie' if defined?(::Rails)
 
 begin
@@ -144,9 +145,8 @@ module Chewy
     # Be careful, if current prefix is blank, this will destroy all the indexes.
     #
     def massacre
-      result = Chewy.client.indices.delete(index: [Chewy.configuration[:prefix], '*'].delete_if(&:blank?).join(?_))
-      Chewy.wait_for_status if result
-      result
+      Chewy.client.indices.delete(index: [Chewy.configuration[:prefix], '*'].delete_if(&:blank?).join(?_))
+      Chewy.wait_for_status
     end
     alias_method :delete_all, :massacre
 

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -144,8 +144,9 @@ module Chewy
     # Be careful, if current prefix is blank, this will destroy all the indexes.
     #
     def massacre
-      Chewy.client.indices.delete(index: [Chewy.configuration[:prefix], '*'].delete_if(&:blank?).join(?_))
-      Chewy.wait_for_status
+      result = Chewy.client.indices.delete(index: [Chewy.configuration[:prefix], '*'].delete_if(&:blank?).join(?_))
+      Chewy.wait_for_status if result
+      result
     end
     alias_method :delete_all, :massacre
 

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -158,12 +158,12 @@ module Chewy
         # zero-downtime index resetting (described here:
         # http://www.elasticsearch.org/blog/changing-mapping-with-zero-downtime/).
         #
-        #   UsersIndex.reset! Time.now.to_i
+        #   UsersIndex.reset! Time.now.to_i, journal: true
         #
-        def reset! suffix = nil
+        def reset! suffix = nil, journal: false
           if suffix.present? && (indexes = self.indexes).present?
             create! suffix, alias: false
-            result = import suffix: suffix
+            result = import suffix: suffix, journal: journal
             client.indices.update_aliases body: {actions: [
               *indexes.map do |index|
                 {remove: {index: index, alias: index_name}}
@@ -174,7 +174,7 @@ module Chewy
             result
           else
             purge! suffix
-            import
+            import journal: journal
           end
         end
       end

--- a/lib/chewy/journal.rb
+++ b/lib/chewy/journal.rb
@@ -80,6 +80,11 @@ module Chewy
         result
       end
 
+      def delete!
+        Chewy.client.delete_by_query index: index_name, type: type_name, body: {query: {match_all: {}}}
+        Chewy.wait_for_status
+      end
+
       def exists?
         Chewy.client.indices.exists? index: index_name
       end

--- a/lib/chewy/journal.rb
+++ b/lib/chewy/journal.rb
@@ -1,0 +1,99 @@
+module Chewy
+  class Journal
+    JOURNAL_MAPPING = {
+      journal: {
+        properties: {
+          index_name: {type: 'string', index: 'not_analyzed'},
+          type_name: {type: 'string', index: 'not_analyzed'},
+          action: {type: 'string', index: 'not_analyzed'},
+          object_ids: {type: 'string', index: 'not_analyzed'},
+          created_at: {type: 'date', format: 'basic_date_time'}
+        }
+      }
+    }.freeze
+
+    def initialize(index)
+      @records = []
+      @index = index
+    end
+
+    def add(action_objects)
+      @records +=
+        action_objects.map do |action, objects|
+          {
+            index_name: @index.index_name,
+            type_name: @index.type_name,
+            action: action,
+            object_ids: identify(objects),
+            created_at: Time.now.to_i
+          }
+        end
+    end
+
+    def bulk_body
+      @records.map do |record|
+        {
+          create: {
+            _index: self.class.index_name,
+            _type: self.class.type_name,
+            data: record
+          }
+        }
+      end
+    end
+
+    def any_records?
+      @records.any?
+    end
+
+    private
+
+    def identify(objects)
+      @index.adapter.identify(objects)
+    end
+
+    class << self
+      def apply_changes_from(time)
+        entries_from(time).each do |entry|
+          type = Chewy.derive_type("#{entry['index_name']}##{entry['type_name']}")
+          type.import(entry['object_ids'], journal: false)
+        end
+      end
+
+      def entries_from(time)
+        query = {
+          filter: {
+            range: {
+              created_at: {
+                gte: time.to_i
+              }
+            }
+          }
+        }
+        Chewy.client.search(index: index_name, type: type_name, body: query, sort: 'created_at')['hits']['hits'].map { |r| r['_source'] }
+      end
+
+      def create
+        return if exists?
+        result = Chewy.client.indices.create index: index_name, body: {settings: Chewy.settings, mappings: JOURNAL_MAPPING}
+        Chewy.wait_for_status if result
+        result
+      end
+
+      def exists?
+        Chewy.client.indices.exists? index: index_name
+      end
+
+      def index_name
+        [
+          Chewy.configuration[:prefix],
+          Chewy.configuration[:journal_name] || 'chewy_journal'
+        ].reject(&:blank?).join('_')
+      end
+
+      def type_name
+        JOURNAL_MAPPING.keys.first
+      end
+    end
+  end
+end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -47,7 +47,9 @@ module Chewy
       def reset_index *indexes
         normalize_indexes(indexes).each do |index|
           puts "Resetting #{index}"
-          index.reset! (Time.now.to_f * 1000).round
+          time = Time.now
+          index.reset! (time.to_f * 1000).round
+          Chewy::Journal.apply_changes_from(time) if index.journal?
         end
       end
 

--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -13,7 +13,7 @@ require 'chewy/type/adapter/sequel'
 
 module Chewy
   class Type
-    IMPORT_OPTIONS_KEYS = [:batch_size, :bulk_size, :refresh, :consistency, :replication, :raw_import]
+    IMPORT_OPTIONS_KEYS = [:batch_size, :bulk_size, :refresh, :consistency, :replication, :raw_import, :journal]
 
     include Search
     include Mapping

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -4,17 +4,6 @@ module Chewy
       extend ActiveSupport::Concern
 
       BULK_OPTIONS = [:suffix, :bulk_size, :refresh, :consistency, :replication]
-      JOURNAL_MAPPING = {
-        _default_: {
-          properties: {
-            index_name: { type: 'string', index: 'not_analyzed' },
-            type_name: { type: 'string', index: 'not_analyzed' },
-            action: { type: 'string', index: 'not_analyzed' },
-            object_ids: { type: 'string', index: 'not_analyzed' },
-            created_at: { type: 'date', format: 'basic_date_time' }
-          }
-        }
-      }
 
       module ClassMethods
         # Perform import operation for specified documents.
@@ -25,7 +14,7 @@ module Chewy
         #   UsersIndex::User.import [1, 2, 3]                # imports users with specified ids
         #   UsersIndex::User.import users                    # imports users collection
         #   UsersIndex::User.import suffix: Time.now.to_i    # imports data to index with specified suffix if such exists
-        #   UsersIndex::User.import journal: true            # import will journal all the actions into special index
+        #   UsersIndex::User.import journal: true            # import will record all the actions into special journal index
         #   UsersIndex::User.import batch_size: 300          # import batch size
         #   UsersIndex::User.import bulk_size: 10.megabytes  # import ElasticSearch bulk size in bytes
         #   UsersIndex::User.import refresh: false           # to disable index refreshing after import
@@ -38,19 +27,18 @@ module Chewy
           import_options = args.extract_options!
           import_options.reverse_merge! _default_import_options
           bulk_options = import_options.reject { |k, _| !BULK_OPTIONS.include?(k) }.reverse_merge!(refresh: true)
-          journal = import_options.delete(:journal)
 
           index.create!(bulk_options.slice(:suffix)) unless index.exists?
-          create_journal! if journal
 
           ActiveSupport::Notifications.instrument 'import_objects.chewy', type: self do |payload|
             adapter.import(*args, import_options) do |action_objects|
-              journal_record = journal ? journal_records(action_objects) : []
+              journal = Chewy::Journal.new(self)
+              journal.add(action_objects) if import_options[:journal] || journal?
 
               indexed_objects = build_root.parent_id && fetch_indexed_objects(action_objects.values.flatten)
               body = bulk_body(action_objects, indexed_objects)
 
-              errors = bulk(bulk_options.merge(body: body.concat(journal_record))) if body.present?
+              errors = bulk(bulk_options.merge(body: body, journal: journal)) if body.present?
 
               fill_payload_import payload, action_objects
               fill_payload_errors payload, errors if errors.present?
@@ -82,6 +70,7 @@ module Chewy
           suffix = options.delete(:suffix)
           bulk_size = options.delete(:bulk_size)
           body = options.delete(:body)
+          journal = options.delete(:journal)
           header = { index: index.build_index_name(suffix: suffix), type: type_name }
 
           bodies = if bulk_size
@@ -104,6 +93,11 @@ module Chewy
             [body]
           end
 
+          if journal.any_records?
+            Chewy::Journal.create
+            bodies += [journal.bulk_body]
+          end
+
           items = bodies.map do |body|
             result = client.bulk options.merge(header).merge(body: body)
             result.try(:[], 'items') || []
@@ -113,18 +107,11 @@ module Chewy
           extract_errors items
         end
 
+        def journal?
+          _default_import_options.fetch(:journal) { Chewy.configuration[:journal] }
+        end
+
       private
-
-        def create_journal!
-          index_name = [Chewy.configuration[:prefix], 'chewy_journal'].reject(&:blank?).join(?_)
-          result = client.indices.create index: index_name, mappings: JOURNAL_MAPPING
-          Chewy.wait_for_status if result
-          result
-        end
-
-        def journal_records(action_objects)
-          []
-        end
 
         def bulk_body(action_objects, indexed_objects = nil)
           action_objects.flat_map do |action, objects|

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -33,7 +33,7 @@ module Chewy
           ActiveSupport::Notifications.instrument 'import_objects.chewy', type: self do |payload|
             adapter.import(*args, import_options) do |action_objects|
               journal = Chewy::Journal.new(self)
-              journal.add(action_objects) if import_options[:journal] || journal?
+              journal.add(action_objects) if import_options.fetch(:journal) { journal? }
 
               indexed_objects = build_root.parent_id && fetch_indexed_objects(action_objects.values.flatten)
               body = bulk_body(action_objects, indexed_objects)

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -26,4 +26,18 @@ namespace :chewy do
       end
     end
   end
+
+  desc 'Applies changes that were done from specified moment (as a timestamp)'
+  task apply_changes_from: :environment do |_task, args|
+    Chewy::RakeHelper.subscribed_task_stats do
+      timestamp = args.extras
+
+      if timestamp.empty?
+        puts 'Please specify a timestamp like chewy:apply_changes_from[1469528705]'
+      else
+        time = Time.at(timestamp.first.to_i)
+        Chewy::Journal.apply_changes_from(time)
+      end
+    end
+  end
 end

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -40,4 +40,9 @@ namespace :chewy do
       end
     end
   end
+
+  desc 'Cleans journal index'
+  task clean_journal: :environment do |_task, _args|
+    Chewy::Journal.delete!
+  end
 end

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -390,5 +390,27 @@ describe Chewy::Index::Actions do
         specify { expect(Chewy.client.indices.exists(index: 'cities_2013')).to eq(false) }
       end
     end
+
+    context 'journaling' do
+      before do
+        begin
+          Chewy.client.indices.delete(index: Chewy::Journal.index_name)
+        rescue Elasticsearch::Transport::Transport::Errors::NotFound
+        end
+      end
+
+      specify do
+        CitiesIndex.reset!
+
+        expect(Chewy.client.indices.exists?(index: Chewy::Journal.index_name)).to eq false
+      end
+
+      specify do
+        CitiesIndex.reset! journal: true
+
+        expect(Chewy.client.indices.exists?(index: Chewy::Journal.index_name)).to eq true
+        expect(Chewy.client.count(index: Chewy::Journal.index_name)['count']).not_to eq 0
+      end
+    end
   end
 end

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -1,0 +1,139 @@
+describe Chewy::Journal do
+  context 'journaling', orm: true do
+    before do
+      stub_model(:city) do
+        update_index 'places#city', :self
+      end
+      stub_model(:country) do
+        update_index 'places#country', :self
+      end
+
+      stub_index(:places) do
+        define_type City do
+          default_import_options journal: true
+        end
+        define_type Country do
+          default_import_options journal: true
+        end
+      end
+
+      Chewy.massacre
+      begin
+        Chewy.client.indices.delete(index: Chewy::Journal.index_name)
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound
+      end
+      Timecop.freeze(time)
+    end
+
+    after do
+      Timecop.return
+    end
+
+    let(:time) { Time.now }
+    let(:import_time) { time + 1 }
+    let(:update_time) { time + 2 }
+    let(:destroy_time) { time + 3 }
+
+    def timestamp(time)
+      time.to_i
+    end
+
+    specify do
+      Chewy.strategy(:urgent) do
+        cities = Array.new(2) { |i| City.create!(id: i + 1) }
+        countries = Array.new(2) { |i| Country.create!(id: i + 1) }
+        Country.create!(id: 3)
+
+        Timecop.freeze(import_time)
+        PlacesIndex.import
+
+        expect(Chewy.client.indices.exists?(index: Chewy::Journal.index_name)).to eq true
+
+        Timecop.freeze(update_time)
+        cities.first.update_attributes!(name: 'Supername')
+
+        Timecop.freeze(destroy_time)
+        countries.last.destroy
+
+        journal_records = Chewy.client.search(index: Chewy::Journal.index_name, type: Chewy::Journal.type_name, sort: 'created_at')['hits']['hits'].map { |r| r['_source'] }
+
+        expected_journal = [
+          {
+            'index_name' => 'places',
+            'type_name' => 'city',
+            'action' => 'index',
+            'object_ids' => [1],
+            'created_at' => time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'city',
+            'action' => 'index',
+            'object_ids' => [2],
+            'created_at' => time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'country',
+            'action' => 'index',
+            'object_ids' => [1],
+            'created_at' => time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'country',
+            'action' => 'index',
+            'object_ids' => [2],
+            'created_at' => time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'country',
+            'action' => 'index',
+            'object_ids' => [3],
+            'created_at' => time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'city',
+            'action' => 'index',
+            'object_ids' => [1, 2],
+            'created_at' => import_time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'country',
+            'action' => 'index',
+            'object_ids' => [1, 2, 3],
+            'created_at' => import_time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'city',
+            'action' => 'index',
+            'object_ids' => [1],
+            'created_at' => update_time.to_i
+          },
+          {
+            'index_name' => 'places',
+            'type_name' => 'country',
+            'action' => 'delete',
+            'object_ids' => [2],
+            'created_at' => destroy_time.to_i
+          }
+        ]
+
+        expect(Chewy.client.count(index: Chewy::Journal.index_name)['count']).to eq 9
+        expect(journal_records).to eq expected_journal
+        expect(Chewy::Journal.entries_from(import_time).length).to eq 4
+
+        # simulate lost data
+        Chewy.client.delete(index: 'places', type: 'city', id: 1, refresh: true)
+        expect(PlacesIndex::City.all.to_a.length).to eq 1
+
+        Chewy::Journal.apply_changes_from(time)
+        expect(PlacesIndex::City.all.to_a.length).to eq 2
+      end
+    end
+  end
+end

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -133,6 +133,10 @@ describe Chewy::Journal do
 
         Chewy::Journal.apply_changes_from(time)
         expect(PlacesIndex::City.all.to_a.length).to eq 2
+
+        Chewy::Journal.delete!
+        expect(Chewy.client.indices.exists?(index: Chewy::Journal.index_name)).to eq true
+        expect(Chewy.client.count(index: Chewy::Journal.index_name)['count']).to eq 0
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ end
 require 'rspec/its'
 require 'rspec/collection_matchers'
 
+require 'timecop'
+
 Kaminari::Hooks.init if defined?(::Kaminari)
 
 require 'support/fail_helpers'


### PR DESCRIPTION
It adds journaling for all actions that were made on records. It is optional and can be set using import options, `default_import_options` and Chewy configuration. 

### TODO
- [x] Add changes applying
- [x] Add rake task for changes applying
