### PR TITLE
Only require chewy railtie when Rails::Railtie is defined

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -30,7 +30,7 @@ require 'chewy/index'
 require 'chewy/type'
 require 'chewy/fields/base'
 require 'chewy/fields/root'
-require 'chewy/railtie' if defined?(::Rails)
+require 'chewy/railtie' if defined?(::Rails) && defined?(::Rails::Railtie)
 
 begin
   require 'kaminari'


### PR DESCRIPTION
 - When using ActiveSupport's inflector in a standalone
 circumstance, the Rails module will be defined, but
 Rails::Railtie will not; this causes Chewy to break bootstrapping
 during bundling


The stack trace of this issue looks roughly like this ...

```bash
Bundler::GemRequireError: There was an error while trying to load the gem 'chewy'.
Gem Load Error is: uninitialized constant Rails::Railtie
Backtrace for gem load error is:
/usr/local/rvm/gems/ruby-2.1.9/gems/chewy-0.7.0/lib/chewy/railtie.rb:2:in `<module:Chewy>'
/usr/local/rvm/gems/ruby-2.1.9/gems/chewy-0.7.0/lib/chewy/railtie.rb:1:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.1.9/gems/chewy-0.7.0/lib/chewy.rb:38:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:86:in `require'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:86:in `block (2 levels) in require'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:81:in `each'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:81:in `block in require'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:70:in `each'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler/runtime.rb:70:in `require'
/usr/local/rvm/gems/ruby-2.1.9@global/gems/bundler-1.12.5/lib/bundler.rb:102:in `require'
```
