### PR TITLE
Allow app/chewy location to be changed via yml config

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -40,7 +40,7 @@ module Chewy
 
       # Where Chewy expects to find index definitions
       # within a Rails app folder.
-      :index_definition_path
+      :indices_path
 
     def self.delegated
       public_instance_methods - self.superclass.public_instance_methods - Singleton.public_instance_methods
@@ -53,7 +53,7 @@ module Chewy
       @root_strategy = :base
       @request_strategy = :atomic
       @use_after_commit_callbacks = true
-      @index_definition_path = 'app/chewy'
+      @indices_path = 'app/chewy'
     end
 
     def transport_logger= logger

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -36,7 +36,11 @@ module Chewy
       # in tests with transactional fixtures or transactional
       # DatabaseCleaner strategy.
       #
-      :use_after_commit_callbacks
+      :use_after_commit_callbacks,
+
+      # Where Chewy expects to find index definitions
+      # within a Rails app folder.
+      :index_definition_path
 
     def self.delegated
       public_instance_methods - self.superclass.public_instance_methods - Singleton.public_instance_methods
@@ -49,6 +53,7 @@ module Chewy
       @root_strategy = :base
       @request_strategy = :atomic
       @use_after_commit_callbacks = true
+      @index_definition_path = 'app/chewy'
     end
 
     def transport_logger= logger

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -70,9 +70,9 @@ module Chewy
       app.config.middleware.insert_after(Rails::Rack::Logger, RequestStrategy)
     end
 
-    initializer 'chewy.add_index_definition_path' do |app|
+    initializer 'chewy.add_indices_path' do |app|
       Chewy::Railtie.all_engines.each do |engine|
-        engine.paths.add Chewy.configuration[:index_definition_path]
+        engine.paths.add Chewy.configuration[:indices_path]
       end
     end
   end

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -70,9 +70,9 @@ module Chewy
       app.config.middleware.insert_after(Rails::Rack::Logger, RequestStrategy)
     end
 
-    initializer 'chewy.add_app_chewy_path' do |app|
+    initializer 'chewy.add_index_definition_path' do |app|
       Chewy::Railtie.all_engines.each do |engine|
-        engine.paths.add 'app/chewy'
+        engine.paths.add Chewy.configuration[:index_definition_path]
       end
     end
   end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -20,7 +20,7 @@ module Chewy
       end
 
       def eager_load_chewy!
-        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths['app/chewy'] }.compact.map(&:existent).flatten.uniq
+        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths[ Chewy.configuration[:index_definition_path] ] }.compact.map(&:existent).flatten.uniq
 
         dirs.each do |dir|
           Dir.glob(File.join(dir, '**/*.rb')).each do |file|

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -20,7 +20,7 @@ module Chewy
       end
 
       def eager_load_chewy!
-        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths[ Chewy.configuration[:index_definition_path] ] }.compact.map(&:existent).flatten.uniq
+        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths[ Chewy.configuration[:indices_path] ] }.compact.map(&:existent).flatten.uniq
 
         dirs.each do |dir|
           Dir.glob(File.join(dir, '**/*.rb')).each do |file|

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -12,7 +12,7 @@ describe Chewy::Config do
   its(:root_strategy) { should == :base }
   its(:request_strategy) { should == :atomic }
   its(:use_after_commit_callbacks) { should == true }
-  its(:index_definition_path) { should == 'app/chewy' }
+  its(:indices_path) { should == 'app/chewy' }
 
   describe '#transport_logger=' do
     let(:logger) { Logger.new('/dev/null') }

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -12,6 +12,7 @@ describe Chewy::Config do
   its(:root_strategy) { should == :base }
   its(:request_strategy) { should == :atomic }
   its(:use_after_commit_callbacks) { should == true }
+  its(:index_definition_path) { should == 'app/chewy' }
 
   describe '#transport_logger=' do
     let(:logger) { Logger.new('/dev/null') }


### PR DESCRIPTION
Hello again!

In our rails application directory we have the following folders:

```
assets/
contexts/
controllers/
errors/
exporters/
helpers/
jobs/
mailers/
models/
policies/
serializers/
views/
```

While integrating the Chewy gem, I added the `app/chewy` folder to the application. There were a few complaints that 'chewy' didn't match the convention applied in the `app/` directory, and so I was able to change it to `app/indices` with a little creative monkey patching.

This patch allows the directory to be set with a new config option called `index_definition_path`.

I tried to find every place the path was hard coded and replace with `Chewy.configuration[:index_definition_path]`.

Additionally, the default setting is `app/chewy` so current deployments shouldn't need to change anything.

Thoughts?

Thanks!
