### PR TITLE
Add the `track_scores` option to the query

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 274
+  Max: 277
 
 # Offense count: 14
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   * Rake tasks support multiple indexes and exceptions: `rake chewy:reset[users,projects]`, `rake chewy:update[-projects]`
 
   * Witchcraft™ supports dynamically generated procs with variables from closure.
+  
+  * Add the `track_scores` option to the query; `_score` to be computed and tracked even when there are no `_score` in sort. (@dmitry)
 
 ## Bugfixes
 

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -329,7 +329,7 @@ module Chewy
     #
     # UsersIndex.query(...).track_scores(true)
     #
-    def track_scores value
+    def track_scores(value)
       chain { criteria.update_request_options track_scores: value }
     end
 

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -325,6 +325,14 @@ module Chewy
       chain { criteria.update_request_options min_score: value }
     end
 
+    # Elasticsearch track_scores option support
+    #
+    # UsersIndex.query(...).track_scores(true)
+    #
+    def track_scores value
+      chain { criteria.update_request_options track_scores: value }
+    end
+
     # Adds facets section to the search request.
     # All the chained facets a merged and added to the
     # search request

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -10,7 +10,8 @@ module Chewy
         :boost_factor, :weight, :random_score, :field_value_factor, :decay, :aggregations,
         :suggest, :none, :strategy, :query, :filter, :post_filter, :boost_mode,
         :score_mode, :order, :reorder, :only, :types, :delete_all, :find, :total,
-        :total_count, :total_entries, :unlimited, :script_fields, to: :all
+        :total_count, :total_entries, :unlimited, :script_fields, :track_scores,
+        to: :all
     end
 
     module ClassMethods

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -107,6 +107,14 @@ describe Chewy::Query do
     specify { expect(subject.offset { 20 / 2 }.criteria.request_body[:body]).to include(from: 10) }
   end
 
+  describe '#track_scores' do
+    specify { expect(subject.track_scores(true)).to be_a described_class }
+    specify { expect(subject.track_scores(true)).not_to eq(subject) }
+    specify { expect(subject.track_scores(true).criteria.request_options).to include(track_scores: true) }
+    specify { expect { subject.track_scores(true) }.not_to change { subject.criteria.request_options } }
+    specify { expect(subject.track_scores(false).criteria.request_body[:body]).to include(track_scores: false) }
+  end
+
   describe '#script_fields' do
     specify { expect(subject.script_fields(distance: 'test()')).to be_a described_class }
     specify { expect(subject.script_fields(distance: 'test()')).not_to eq(subject) }


### PR DESCRIPTION
`_score` to be computed and tracked even when there are no `_score` in sort.

More here: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html