### PR TITLE
Make journals work with elasticsearch 2.x

### DIFF
--- a/lib/chewy/journal.rb
+++ b/lib/chewy/journal.rb
@@ -7,7 +7,7 @@ module Chewy
           type_name: { type: 'string', index: 'not_analyzed' },
           action: { type: 'string', index: 'not_analyzed' },
           object_ids: { type: 'string', index: 'not_analyzed' },
-          created_at: { type: 'date', format: 'basic_date_time' }
+          created_at: { type: 'date' }
         }
       }
     }.freeze


### PR DESCRIPTION
Running the specs with elasticsearch 2.1.2 reveals an error in [spec/chewy/index/actions_spec#413](https://github.com/toptal/chewy/blob/master/spec/chewy/index/actions_spec.rb#L413)

```
rspec ./spec/chewy/index/actions_spec.rb:409 # Chewy::Index::Actions.reset! journaling should not eq 0
```

Digging into this with `pry` reveals the following error while executing `import`

```ruby
{:create=>
  {{"type"=>"mapper_parsing_exception",
    "reason"=>"failed to parse [created_at]",
    "caused_by"=>{"type"=>"illegal_argument_exception", "reason"=>"Invalid format: \"1474461120\" is malformed at \"20\""}}=>
    ["AVdMuzzyVa0tBwCq2J07"]}}
```

The problem arises because
* the mapping stats, that `created_at` is a date with the format `basic_date_time`
  * see [lib/chewy/journal.rb#L10](https://github.com/toptal/chewy/blob/master/lib/chewy/journal.rb#L10)
* but is given as epoch
  * see [lib/chewy/journal.rb#L30](https://github.com/toptal/chewy/blob/master/lib/chewy/journal.rb#L30)

This is ok for elasticsearch < 2, because
* _The date type will also accept a long number representing UTC milliseconds since the epoch, regardless of the format it can handle._
  * see [https://www.elastic.co/guide/en/elasticsearch/reference/1.4/mapping-core-types.html#date](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/mapping-core-types.html#date)

For elasticsearch > 2 it isn't ok, because the given epoch does not match the specified format.

My solution for this is to drop the `format` specification and let the mapping simply state that `created_at` is a date
* should be ok for elasticsearch < 2, which will recognize the given epoch as before
* should be ok for elasticsearch >= 2, because if no format is given it defaults to `"strict_date_optional_time||epoch_millis"`
  * see [https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html)