### PR TITLE
Silence rubocop warning about unnecessay splat expansion

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -126,7 +126,7 @@ module Chewy
     def yaml_settings
       @yaml_settings ||= begin
         if defined?(Rails)
-          file = Rails.root.join(*%w(config chewy.yml)) # rubocop:disable Lint/UnneededSplatExpansion
+          file = Rails.root.join('config', 'chewy.yml')
 
           if File.exist?(file)
             yaml = ERB.new(File.read(file)).result

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -126,7 +126,7 @@ module Chewy
     def yaml_settings
       @yaml_settings ||= begin
         if defined?(Rails)
-          file = Rails.root.join(*%w(config chewy.yml))
+          file = Rails.root.join(*%w(config chewy.yml)) # rubocop:disable Lint/UnneededSplatExpansion
 
           if File.exist?(file)
             yaml = ERB.new(File.read(file)).result


### PR DESCRIPTION
Currently, running rubocop results in

```
lib/chewy/config.rb:129:34: W: Unnecessary splat expansion.
          file = Rails.root.join(*%w(config chewy.yml))
```

- the expansion is needed here, unless one would change the code
- because rubocop does not recognize that this is needed, it should be
  ok to disable this cop for this line using an end-of-line comment

@pyromaniac I would like to request to merge this or an equivalent fix soon, so that I can rebase #428 with this. Currently all tests on travis seem to fail only because of this single rubocop warning.