### PR TITLE
Use default indices_path path

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -112,6 +112,7 @@ module Chewy
     def configuration
       yaml_settings.merge(settings.deep_symbolize_keys).tap do |configuration|
         configuration[:logger] = transport_logger if transport_logger
+        configuration[:indices_path] = indices_path if indices_path
         configuration.merge!(tracer: transport_tracer) if transport_tracer
       end
     end


### PR DESCRIPTION
Once I run `rake chewy:reset` it raised an error with:

```
TypeError: no implicit conversion of nil into String
```

Once I set `indices_path` in a chewy.yml file then this issue was solved.
Since this change now `indices_path` used by default, so you don't need to set it through chewy.yml.