### PR TITLE
Only apply journal for current index when resetting

### DIFF
--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -50,7 +50,7 @@ module Chewy
           index.reset!((time.to_f * 1000).round)
           if index.journal?
             Chewy::Journal.create
-            Chewy::Journal.apply_changes_from(time, only: index)
+            Chewy::Journal.apply_changes_from(time, only: [index])
           end
         end
       end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -50,7 +50,7 @@ module Chewy
           index.reset!((time.to_f * 1000).round)
           if index.journal?
             Chewy::Journal.create
-            Chewy::Journal.apply_changes_from(time)
+            Chewy::Journal.apply_changes_from(time, only: index)
           end
         end
       end

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -210,9 +210,16 @@ describe Chewy::Journal do
           expect(CountryIndex.all.to_a.length).to eq 1
 
           # Replay on specific index
-          Chewy::Journal.new(CityIndex).apply_changes_from(time)
+          Chewy::Journal.apply_changes_from(time, only: [CityIndex])
           expect(CityIndex.all.to_a.length).to eq 2
           expect(CountryIndex.all.to_a.length).to eq 1
+
+          # Replay on both
+          Chewy.client.delete(index: 'city', type: 'city', id: 1, refresh: true)
+          expect(CityIndex.all.to_a.length).to eq 1
+          Chewy::Journal.apply_changes_from(time, only: [CityIndex, CountryIndex])
+          expect(CityIndex.all.to_a.length).to eq 2
+          expect(CountryIndex.all.to_a.length).to eq 2
         end
       end
     end

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -169,5 +169,52 @@ describe Chewy::Journal do
         end
       end
     end
+
+    context '.apply_changes_from with an index filter' do
+      let(:time) { Time.now }
+
+      before do
+        stub_model(:city) do
+          update_index 'city', :self
+        end
+        stub_model(:country) do
+          update_index 'country', :self
+        end
+
+        stub_index('city') do
+          define_type City do
+            default_import_options journal: true
+          end
+        end
+        stub_index('country') do
+          define_type Country do
+            default_import_options journal: true
+          end
+        end
+
+        Chewy.massacre
+        Timecop.freeze(time)
+      end
+
+      specify do
+        Chewy.strategy(:urgent) do
+          Array.new(2) { |i| City.create!(id: i + 1) }
+          Array.new(2) { |i| Country.create!(id: i + 1) }
+          expect(CityIndex.all.to_a.length).to eq 2
+          expect(CountryIndex.all.to_a.length).to eq 2
+
+          # simulate lost data
+          Chewy.client.delete(index: 'city', type: 'city', id: 1, refresh: true)
+          Chewy.client.delete(index: 'country', type: 'country', id: 1, refresh: true)
+          expect(CityIndex.all.to_a.length).to eq 1
+          expect(CountryIndex.all.to_a.length).to eq 1
+
+          # Replay on specific index
+          Chewy::Journal.new(CityIndex).apply_changes_from(time)
+          expect(CityIndex.all.to_a.length).to eq 2
+          expect(CountryIndex.all.to_a.length).to eq 1
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When resetting an index that has journaling, the current code actually replays all the journal entries, no matter which index has just been reset.

This PR only applies journal entries for the given index. I find my code a bit clunky (the new `query` method).

Any thoughts?