### PR TITLE
Fixed indices_path config setting

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -112,7 +112,7 @@ module Chewy
     def configuration
       yaml_settings.merge(settings.deep_symbolize_keys).tap do |configuration|
         configuration[:logger] = transport_logger if transport_logger
-        configuration[:indices_path] = indices_path if indices_path
+        configuration[:indices_path] ||= indices_path if indices_path
         configuration.merge!(tracer: transport_tracer) if transport_tracer
       end
     end


### PR DESCRIPTION
This bug seems to have been introduced by https://github.com/toptal/chewy/pull/433.

The `indices_path` setting from config will always be overwritten by `indices_path` which is `app/chewy`.

`configuration[:indices_path] = indices_path if indices_path`

This prevents `indices_path` setting from config from being overwritten by indices_path if the setting is not nil.