### PR TITLE
Add chewy as the default Sidekiq queue

### DIFF
--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -13,6 +13,8 @@ module Chewy
       class Worker
         include ::Sidekiq::Worker
 
+        sidekiq_options queue: :chewy
+
         def perform(type, ids, options = {})
           type.constantize.import!(ids, options)
         end


### PR DESCRIPTION
I added the same name of  `queue` when `Sidekiq` strategy is being invoked. The `ActiveJob` and `Resque` contain default queue named `chewy`, so might be helpful to add to `Sidekiq` as well.