### PR TITLE
Make sidekiq queue configurable

### DIFF
--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -13,8 +13,6 @@ module Chewy
       class Worker
         include ::Sidekiq::Worker
 
-        sidekiq_options queue: :chewy
-
         def perform(type, ids, options = {})
           type.constantize.import!(ids, options)
         end
@@ -23,7 +21,7 @@ module Chewy
       def leave
         @stash.each do |type, ids|
           next if ids.empty?
-          Sidekiq::Client.push(
+          ::Sidekiq::Client.push(
             'queue' => sidekiq_queue,
             'class' => Chewy::Strategy::Sidekiq::Worker,
             'args'  => [type.name, ids]

--- a/lib/chewy/type/witchcraft.rb
+++ b/lib/chewy/type/witchcraft.rb
@@ -1,6 +1,6 @@
 begin
   require 'method_source'
-  # require 'parser/current'
+  require 'parser/current'
   require 'unparser'
 rescue LoadError
   nil

--- a/lib/chewy/type/witchcraft.rb
+++ b/lib/chewy/type/witchcraft.rb
@@ -1,6 +1,6 @@
 begin
   require 'method_source'
-  require 'parser/current'
+  # require 'parser/current'
   require 'unparser'
 rescue LoadError
   nil

--- a/spec/chewy/strategy/sidekiq_spec.rb
+++ b/spec/chewy/strategy/sidekiq_spec.rb
@@ -25,6 +25,8 @@ if defined?(::Sidekiq)
     end
 
     specify do
+      Chewy.settings[:sidekiq] = { queue: 'low' }
+      expect(::Sidekiq::Client).to receive(:push).with(hash_including('queue' => 'low')).and_call_original
       ::Sidekiq::Testing.inline! do
         expect { [city, other_city].map(&:save!) }
           .to update_index(CitiesIndex::City, strategy: :sidekiq)


### PR DESCRIPTION
This allows users to configure wich sidekiq queue to use,
so that the default job/strategy can be used with existing
setups.
