### PR TITLE
Added specs for indices_path setting on configuration

### DIFF
--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -49,4 +49,12 @@ describe Chewy::Config do
         .to change { subject.configuration[:tracer] }.from(nil).to(tracer)
     end
   end
+
+  describe '#configuration' do
+    before { subject.settings = { indices_path: 'app/custom_indices_path' } }
+
+    specify do
+      expect(subject.configuration).to include(indices_path: 'app/custom_indices_path')
+    end
+  end
 end


### PR DESCRIPTION
This is adding a spec for https://github.com/toptal/chewy/pull/436

This test makes sure that the `indices_path` config in settings is not overridden by the default `indices_path`.