### PR TITLE
Add preference param to Query

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 277
+  Max: 280
 
 # Offense count: 14
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   
   * Add the `track_scores` option to the query; `_score` to be computed and tracked even when there are no `_score` in sort. (@dmitry)
 
+  * Added `Query#preference` for specifying shard replicas to query against. (@menglewis)
+
 ## Bugfixes
 
   * Fix routing_missing_exception on delete with parent missing (@guigs, #398)

--- a/lib/chewy/query.rb
+++ b/lib/chewy/query.rb
@@ -515,6 +515,15 @@ module Chewy
       chain { criteria.update_scores scoring }
     end
 
+    # Sets <tt>preference</tt> for request.
+    # For instance, one can use <tt>preference=_primary</tt> to execute only on the primary shards.
+    #
+    #   scope = UsersIndex.preference(:_primary)
+    #
+    def preference(value)
+      chain { criteria.update_search_options preference: value }
+    end
+
     # Sets elasticsearch <tt>aggregations</tt> search request param
     #
     #  UsersIndex.filter{ name == 'Johny' }.aggregations(category_id: {terms: {field: 'category_ids'}})

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -10,7 +10,7 @@ module Chewy
         :boost_factor, :weight, :random_score, :field_value_factor, :decay, :aggregations,
         :suggest, :none, :strategy, :query, :filter, :post_filter, :boost_mode,
         :score_mode, :order, :reorder, :only, :types, :delete_all, :find, :total,
-        :total_count, :total_entries, :unlimited, :script_fields, :track_scores,
+        :total_count, :total_entries, :unlimited, :script_fields, :track_scores, :preference,
         to: :all
     end
 

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -195,6 +195,14 @@ describe Chewy::Query do
     end
   end
 
+  describe '#preference' do
+    specify { expect(subject.preference(:_primary)).to be_a described_class }
+    specify { expect(subject.preference(:_primary)).not_to eq(subject) }
+    specify { expect(subject.preference(:_primary).criteria.search_options).to include(preference: :_primary) }
+    specify { expect { subject.preference(:_primary) }.not_to change { subject.criteria.search_options } }
+    specify { expect(subject.preference(:_primary).criteria.request_body).to include(preference: :_primary) }
+  end
+
   describe '#facets' do
     specify do
       skip_on_version_lt('2.0')


### PR DESCRIPTION
This PR enables the `preference` option on `Query` which allows the user to control the preference for determining which shard replicas are used for a search request.

See: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-preference.html