### PR TITLE
Support Multi Instance Setup through Proc settings and Dynamic Client Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 .rvmrc
 _site
 .sass-cache
+.idea/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ The logger may be set explicitly:
 Chewy.logger = Logger.new(STDOUT)
 ```
 
+#### Multi Tenant/Instance Setup
+It is possible to provide a `Proc` value for any setting key to have this called at runtime.
+This is useful particularly to use if you wish to run a multi-tenanted environment where tenants may have a dedicated elastic search instance.
+
+**Important:** You should specify an `instance_identifier` as a `Proc` when running multiple instances. 
+The `Proc` should return a unique identifer for the current tenant or instance.
+If you do not provide this then internally the ES client will be cached incorrectly and your tenants may result in sending queries to the wrong instance.
+
+For example:
+
+  ```ruby
+  Chewy.settings = {
+    host:                Proc.new { some_host_value },
+    instance_identifier: Proc.new { some_unique_instance_identifier }
+  }
+  ```
+
 See [config.rb](lib/chewy/config.rb) for more details.
 
 ### Index definition

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -131,7 +131,7 @@ module Chewy
     # Main elasticsearch-ruby client instance
     #
     def client
-      Thread.current[:chewy_client] ||= begin
+      Thread.current[client_key] ||= begin
         client_configuration = configuration.deep_dup
         client_configuration.delete(:prefix) # used by Chewy, not relevant to Elasticsearch::Client
         block = client_configuration[:transport_options].try(:delete, :proc)

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -112,7 +112,7 @@ module Chewy
     def configuration
       yaml_settings.merge(settings.deep_symbolize_keys).tap do |configuration|
         configuration[:logger] = transport_logger if transport_logger
-        configuration[:indices_path] = indices_path if indices_path
+        configuration[:indices_path] ||= indices_path if indices_path
         configuration.merge!(tracer: transport_tracer) if transport_tracer
       end
     end

--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -13,6 +13,8 @@ module Chewy
       class Worker
         include ::Sidekiq::Worker
 
+        sidekiq_options queue: :chewy
+
         def perform(type, ids, options = {})
           type.constantize.import!(ids, options)
         end

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -51,10 +51,97 @@ describe Chewy::Config do
   end
 
   describe '#configuration' do
-    before { subject.settings = { indices_path: 'app/custom_indices_path' } }
 
-    specify do
-      expect(subject.configuration).to include(indices_path: 'app/custom_indices_path')
+    let(:configuration) { subject.configuration }
+    before { subject.settings = settings }
+
+    describe 'custom settings' do
+
+      let(:settings) { { indices_path: 'app/custom_indices_path'} }
+
+      specify do
+        expect(configuration).to include(indices_path: 'app/custom_indices_path')
+      end
+    end
+
+    describe 'host value' do
+
+      let(:settings) { { host: host } }
+
+      context 'when host value is a string' do
+
+        let(:host) { 'localhost:9200' }
+
+        it 'returns the host value as is' do
+          expect(configuration[:host]).to eq(host)
+        end
+      end
+
+      context 'when host value is a Proc' do
+
+        let(:host_lambda_value) { 'localhost:9222' }
+        let(:host) { lambda { host_lambda_value } }
+
+        it 'executes the lambda and sets host to the return value' do
+          expect(configuration[:host]).to eq(host_lambda_value)
+        end
+      end
+    end
+
+    describe 'host value' do
+
+      let(:settings) { { host: host } }
+
+      context 'when host value is a string' do
+
+        let(:host) { 'localhost:9200' }
+
+        it 'returns the host value as is' do
+          expect(configuration[:host]).to eq(host)
+        end
+      end
+
+      context 'when host value is a lambda' do
+
+        let(:host_lambda_value) { 'localhost:9222' }
+        let(:host) { lambda { host_lambda_value } }
+
+        it 'executes the lambda and sets host to the return value' do
+          expect(configuration[:host]).to eq(host_lambda_value)
+        end
+      end
+    end
+  end
+
+  describe '#client_key' do
+
+    before { subject.settings = settings }
+
+    context 'when instance_identifier is not set' do
+
+      let(:settings) { {} }
+
+      it 'returns :chewy_client' do
+        expect(subject.client_key).to eq(:chewy_client)
+      end
+    end
+
+    context 'when instance_identifier is a string' do
+
+      let(:settings) { { instance_identifier: 'acme' } }
+
+      it 'returns a client key that includes the instance_identifier' do
+        expect(subject.client_key).to eq(:chewy_client_acme)
+      end
+    end
+
+    context 'when instance_identifier is a Proc' do
+
+      let(:settings) { { instance_identifier: lambda { 'acme_proc' } } }
+
+      it 'returns a client key the value returned from the Proc' do
+        expect(subject.client_key).to eq(:chewy_client_acme_proc)
+      end
     end
   end
 end

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -49,4 +49,12 @@ describe Chewy::Config do
         .to change { subject.configuration[:tracer] }.from(nil).to(tracer)
     end
   end
+
+  describe '#configuration' do
+    before { subject.settings = { indices_path: 'app/custom_indices_path' } }
+
+    specify do
+      expect(subject.configuration).to include(indices_path: 'app/custom_indices_path')
+    end
+  end
 end


### PR DESCRIPTION
This allows a multi instance Chewy/ES setup by allowing Procs to be specified for setting values.
The Proc values will be determined at runtime and the ES client cached as normal.

To avoid client cacheing clashes between tenants we specify an instance_identifier key that should also be a Proc.
e.g:

``` ruby
Chewy.settings = {
    host:                Proc.new { elastic_host_for_tenant },
    instance_identifier: Proc.new {tenant_identifier } 
}
```
