### PR TITLE
add able to use Proc for settings

### DIFF
--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -145,8 +145,8 @@ module Chewy
     # It is possible to store analyzers settings in Chewy repositories
     # and link them form index class. See `Chewy::Index::Settings` for details.
     #
-    def self.settings(params)
-      self._settings = Chewy::Index::Settings.new params
+    def self.settings(params = {}, &block)
+      self._settings = Chewy::Index::Settings.new(params, &block)
     end
 
     # Returns list of public class methods defined in current index

--- a/lib/chewy/index/settings.rb
+++ b/lib/chewy/index/settings.rb
@@ -23,12 +23,14 @@ module Chewy
     # might be used as well.
     #
     class Settings
-      def initialize(params = {})
+      def initialize(params = {}, &block)
         @params = params
+        @proc_params = block
       end
 
       def to_hash
         settings = @params.deep_symbolize_keys
+        settings.merge!((@proc_params.call || {}).deep_symbolize_keys) if @proc_params
 
         settings[:analysis] = resolve_analysis(settings[:analysis]) if settings[:analysis]
         if settings[:index] || Chewy.configuration[:index]

--- a/spec/chewy/index/settings_spec.rb
+++ b/spec/chewy/index/settings_spec.rb
@@ -33,11 +33,11 @@ describe Chewy::Index::Settings do
     end
 
     specify do
-      Synonyms = Class.new do
+      stub_const('Synonyms', Class.new do
         def self.synonyms
           ['kaftan => dress']
         end
-      end
+      end)
       expect(
         described_class.new do
           {

--- a/spec/chewy/index/settings_spec.rb
+++ b/spec/chewy/index/settings_spec.rb
@@ -32,6 +32,27 @@ describe Chewy::Index::Settings do
         .to eq(settings: { number_of_nodes: 3, analysis: {} })
     end
 
+    specify do
+      Synonyms = Class.new do
+        def self.synonyms
+          ['kaftan => dress']
+        end
+      end
+      expect(
+        described_class.new do
+          {
+            analysis: { filter: { synonym: { type: 'synonym', synonyms: Synonyms.synonyms } } }
+          }
+        end.to_hash
+      ).to eq(settings: {
+                analysis: { filter: {
+                  synonym: {
+                    type: 'synonym', synonyms: ['kaftan => dress']
+                  }
+                } }
+              })
+    end
+
     context do
       before { Chewy.tokenizer :tokenizer1, options: 42 }
 


### PR DESCRIPTION
Hi Arkadiy (@pyromaniac), I added test.
about case where it may be use:
if we keep  a synonyms/stopwords in db then in the settings we can use synonyms from db
for instance:
```
 class ProductsIndex < Chewy::Index
  settings proc {
    {
      analysis: {
        filter: {
          synonym: {
            type: 'synonym',
            ignore_case: true,
            synonyms: SearchSynonym.synonyms
          },
          
          custom_stop: {
            type: 'stop',
            stopwords: SearchStopWord.terms
          },
.....
```

and we can update settings after changes SearchSynonym.synonyms

```
   Chewy.client.indices.put_settings(
        index: productsIndex.index_name,
        body: {
          index: {
            analysis: {
              filter: {
                synonym: {
                  synonyms: SearchSynonym.synonyms
                }
              } } } }
      )

```