### PR TITLE
Add ability to skip index existence checks on each import

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 172
+  Max: 176
 
 # Offense count: 14
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Chewy is an ODM and wrapper for [the official Elasticsearch client](https://gith
   * [Crutches™ technology] (#crutches-technology)
   * [Witchcraft™ technology] (#witchcraft-technology)
   * [Raw Import] (#raw-import)
+  * [Index creation during import] (#index-creation-during-import)
   * [Journaling] (#journaling)
   * [Types access] (#types-access)
   * [Index manipulation] (#index-manipulation)
@@ -480,6 +481,12 @@ end
 ```
 
 Also, you can pass `:raw_import` option to the `import` method explicitly.
+
+### Index creation during import
+
+By default, when you perform import Chewy checks whether an index exists and creates it if it's absent.
+You can turn off this feature to decrease Elasticsearch hits count.
+To do so you need to set `skip_index_creation_on_import` parameter to `false` in your `config/chewy.yml`
 
 
 ### Journaling

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -202,5 +202,24 @@ module Chewy
       Chewy::Repository.instance
     end
     delegate(*Chewy::Repository.delegated, to: :repository)
+
+    def create_indices
+      Chewy::Index.descendants.each(&:create)
+    end
+
+    def create_indices!
+      Chewy::Index.descendants.each(&:create!)
+    end
+
+    def eager_load!
+      return unless defined?(Chewy::Railtie)
+      dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths[Chewy.configuration[:indices_path]] }.compact.map(&:existent).flatten.uniq
+
+      dirs.each do |dir|
+        Dir.glob(File.join(dir, '**/*.rb')).each do |file|
+          require_dependency file
+        end
+      end
+    end
   end
 end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -25,18 +25,8 @@ module Chewy
         end
       end
 
-      def eager_load_chewy!
-        dirs = Chewy::Railtie.all_engines.map { |engine| engine.paths[Chewy.configuration[:indices_path]] }.compact.map(&:existent).flatten.uniq
-
-        dirs.each do |dir|
-          Dir.glob(File.join(dir, '**/*.rb')).each do |file|
-            require_dependency file
-          end
-        end
-      end
-
       def all_indexes
-        eager_load_chewy!
+        Chewy.eager_load!
         Chewy::Index.descendants
       end
 

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -28,7 +28,7 @@ module Chewy
           import_options.reverse_merge! _default_import_options
           bulk_options = import_options.reject { |k, _| !BULK_OPTIONS.include?(k) }.reverse_merge!(refresh: true)
 
-          index.create!(bulk_options.slice(:suffix)) unless index.exists?
+          assure_index_existence(bulk_options.slice(:suffix))
 
           ActiveSupport::Notifications.instrument 'import_objects.chewy', type: self do |payload|
             adapter.import(*args, import_options) do |action_objects|
@@ -236,6 +236,11 @@ module Chewy
           end
 
           indexed_objects
+        end
+
+        def assure_index_existence(index_options)
+          return if Chewy.configuration[:skip_index_creation_on_import]
+          index.create!(index_options) unless index.exists?
         end
       end
     end

--- a/spec/chewy_spec.rb
+++ b/spec/chewy_spec.rb
@@ -136,4 +136,43 @@ describe Chewy do
 
     after { Thread.current[:chewy_client] = initial_client }
   end
+
+  describe '.create_indices' do
+    before do
+      stub_index(:cities)
+      stub_index(:places)
+
+      # To avoid flaky issues when previous specs were run
+      allow(Chewy::Index).to receive(:descendants).and_return([CitiesIndex, PlacesIndex])
+
+      Chewy.massacre
+    end
+
+    specify do
+      expect(CitiesIndex.exists?).to eq false
+      expect(PlacesIndex.exists?).to eq false
+
+      CitiesIndex.create!
+
+      expect(CitiesIndex.exists?).to eq true
+      expect(PlacesIndex.exists?).to eq false
+
+      expect { Chewy.create_indices }.not_to raise_error
+
+      expect(CitiesIndex.exists?).to eq true
+      expect(PlacesIndex.exists?).to eq true
+    end
+
+    specify '.create_indices!' do
+      expect(CitiesIndex.exists?).to eq false
+      expect(PlacesIndex.exists?).to eq false
+
+      expect { Chewy.create_indices! }.not_to raise_error
+
+      expect(CitiesIndex.exists?).to eq true
+      expect(PlacesIndex.exists?).to eq true
+
+      expect { Chewy.create_indices! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest)
+    end
+  end
 end


### PR DESCRIPTION
It is configurable by `skip_index_creation_on_import` parameter in
`config/chewy.yml`.