### PR TITLE
README: Fix YAML example in journaling manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Also, you can specify journal index name. For example:
 ```yaml
 # config/chewy.yml
 production:
-  journal: true,
+  journal: true
   journal_name: my_super_journal
 ```
 


### PR DESCRIPTION
This PR fixes the documentation of the README YAML configuration to enable journaling.

The previous value would become the String `"true,"`, not the `TrueClass` value.