### PR TITLE
Add ActiveSupport instrumentation for new DSL

### DIFF
--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -925,10 +925,18 @@ module Chewy
         if parameters[:none].value
           {}
         else
-          Chewy.client.search(render.merge(additional))
+          request_body = render.merge(additional)
+          ActiveSupport::Notifications.instrument 'search_query.chewy',
+            request: request_body, indexes: _indexes, types: _types,
+            index: _indexes.one? ? _indexes.first : _indexes,
+            type: _types.one? ? _types.first : _types do
+            begin
+              Chewy.client.search(request_body)
+            rescue Elasticsearch::Transport::Transport::Errors::NotFound
+              {}
+            end
+          end
         end
-      rescue Elasticsearch::Transport::Transport::Errors::NotFound
-        {}
       end
 
       def raw_limit_value

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -36,7 +36,7 @@ module Chewy
           yield(hits) if hits.present?
           break if fetched >= total
           scroll_id = result['_scroll_id']
-          result = Chewy.client.scroll(scroll: scroll, scroll_id: scroll_id)
+          result = perform_scroll(scroll: scroll, scroll_id: scroll_id)
         end
       end
 
@@ -115,6 +115,17 @@ module Chewy
         end
       end
       alias_method :scroll_documents, :scroll_records
+
+    private
+
+      def perform_scroll(body)
+        ActiveSupport::Notifications.instrument 'search_query.chewy',
+          request: body, indexes: _indexes, types: _types,
+          index: _indexes.one? ? _indexes.first : _indexes,
+          type: _types.one? ? _types.first : _types do
+          Chewy.client.scroll(body)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add instrumentation to search and scroll with `search_query.chewy` name.