### PR TITLE
Add default root options setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changes
 
+  * `default_root_options` option (@barthez, #526)
+
   * Partial indexing ability: it is possible to update only specified fields.
 
   * New cool `rake chewy:deploy` task.

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -54,6 +54,10 @@ module Chewy
       # Refresh or not when import async (sidekiq, resque, activejob)
       :disable_refresh_async,
 
+      # Default options for root of Chewy type. Allows to set default options
+      # for type mappings like `_all`.
+      :default_root_options,
+
       # Chewy search request DSL base class, used by every index.
       :search_class
 
@@ -72,6 +76,7 @@ module Chewy
       @reset_no_replicas = false
       @disable_refresh_async = false
       @indices_path = 'app/chewy'
+      @default_root_options = {}
       self.search_class = Chewy::Search::Request
     end
 

--- a/lib/chewy/type/mapping.rb
+++ b/lib/chewy/type/mapping.rb
@@ -191,7 +191,7 @@ module Chewy
 
         def build_root(options = {}, &block)
           return root_object if root_object
-          self.root_object = Chewy::Fields::Root.new(type_name, options)
+          self.root_object = Chewy::Fields::Root.new(type_name, Chewy.default_root_options.merge(options))
           expand_nested(root_object, &block)
           @_current_field = root_object
         end

--- a/spec/chewy/type/mapping_spec.rb
+++ b/spec/chewy/type/mapping_spec.rb
@@ -102,5 +102,16 @@ describe Chewy::Type::Mapping do
     specify { expect(product.root_object.children.map(&:parent)).to eq([product.root_object]) }
     specify { expect(product.root_object.children[0].children.map(&:name)).to eq([:subfield1]) }
     specify { expect(product.root_object.children[0].children.map(&:parent)).to eq([product.root_object.children[0]]) }
+
+    context 'default root options are set' do
+      around do |example|
+        previous_options = Chewy.default_root_options
+        Chewy.default_root_options = {_all: {enabled: false}}
+        example.run
+        Chewy.default_root_options = previous_options
+      end
+
+      specify { expect(product.mappings_hash[:product]).to include(_all: {enabled: false}) }
+    end
   end
 end


### PR DESCRIPTION
Allow setting default type root options. It can be useful when we want to disable _all field for all types.