### PR TITLE
Add default field type setting

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -58,6 +58,9 @@ module Chewy
       # for type mappings like `_all`.
       :default_root_options,
 
+      # Default field type for any field in any Chewy type. Defaults to 'string'.
+      :default_field_type,
+
       # Chewy search request DSL base class, used by every index.
       :search_class
 
@@ -77,6 +80,7 @@ module Chewy
       @disable_refresh_async = false
       @indices_path = 'app/chewy'
       @default_root_options = {}
+      @default_field_type = 'string'.freeze
       self.search_class = Chewy::Search::Request
     end
 

--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -27,7 +27,7 @@ module Chewy
             {}
           end
         mapping.reverse_merge!(options)
-        mapping.reverse_merge!(type: (children.present? ? 'object' : 'string'))
+        mapping.reverse_merge!(type: (children.present? ? 'object' : Chewy.default_field_type))
         {name => mapping}
       end
 

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -8,7 +8,7 @@ module Chewy
     index_name 'chewy_stash'
 
     define_type :specification do
-      field :value, type: 'string', index: 'not_analyzed'
+      field :value, index: 'no'
     end
   end
 end

--- a/spec/chewy/fields/base_spec.rb
+++ b/spec/chewy/fields/base_spec.rb
@@ -152,6 +152,36 @@ describe Chewy::Fields::Base do
         })
       end
 
+      context 'default field type' do
+        around do |example|
+          previous_type = Chewy.default_field_type
+          Chewy.default_field_type = 'text'
+          example.run
+          Chewy.default_field_type = previous_type
+        end
+
+        specify do
+          expect(EventsIndex::Event.mappings_hash).to eq(event: {
+            properties: {
+              id: {type: 'text'},
+              category: {
+                type: 'object',
+                properties: {
+                  id: {type: 'text'},
+                  licenses: {
+                    type: 'object',
+                    properties: {
+                      id: {type: 'text'},
+                      name: {type: 'text'}
+                    }
+                  }
+                }
+              }
+            }
+          })
+        end
+      end
+
       specify do
         expect(EventsIndex::Event.root_object.compose(
                  id: 1, category: {id: 2, licenses: {id: 3, name: 'Name'}}


### PR DESCRIPTION
Allow to sets default type for any field. By default, it is set to 'string'.