### PR TITLE
Elastic filters

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -149,7 +149,7 @@ module Chewy
 
           if File.exist?(file)
             yaml = ERB.new(File.read(file)).result
-            hash = YAML.safe_load(yaml)
+            hash = YAML.safe_load(yaml, [], [], true)
             hash[Rails.env].try(:deep_symbolize_keys) if hash
           end
         end || {}

--- a/lib/chewy/query/compose.rb
+++ b/lib/chewy/query/compose.rb
@@ -8,16 +8,20 @@ module Chewy
 
         if filter.present?
           filtered = if query.present?
-            {query: {filtered: {
-              query: query,
-              filter: filter
-            }}}
+            {
+              query: {
+                bool: {
+                  must: query,
+                  filter: filter
+                }
+              }
+            }
           else
-            {query: {filtered: {
+            {query: {must: {
               filter: filter
             }}}
           end
-          filtered[:query][:filtered][:strategy] = options[:strategy].to_s if options[:strategy].present?
+          raise 'noooo' if filtered[:query][:filtered][:strategy].present? # = options[:strategy].to_s if options[:strategy].present?
           filtered
         elsif query.present?
           {query: query}


### PR DESCRIPTION
Filtered queries do no longer work in Elasticsearch 5 as the DSL changed
from what is encoded in chewy.

I don't assume that will be accepted as is, but I wanted to submit it 
as a proof of concept. I'm still testing if it works as expected.

Also, the "new" yaml loader does safe load and not accepts yaml references,
which is a pain.