### PR TITLE
Make _Parallelizing rake tasks_ h4 (was: h5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,7 +988,7 @@ Right now the approach is that if some data had been updated, but index definiti
 
 Also, there is always full reset alternative with `rake chewy:reset`.
 
-##### Parallelizing rake tasks
+#### Parallelizing rake tasks
 
 Every task described above has its own parallel version. Every parallel rake task takes the number for processes for execution as the first argument and the rest of the arguments are exactly the same as for the non-parallel task version.
 


### PR DESCRIPTION
According to the screenshot, _Parallelizing rake tasks_ should be on the same level as previous items.

Having _Parallelizing rake tasks_ section as a subsection of `chewy:deploy` doesn't really make much sense.

![image](https://user-images.githubusercontent.com/447953/28076081-30650a78-6666-11e7-9207-62c69a24d416.png)

Before:

![image](https://user-images.githubusercontent.com/447953/28076229-a22a39a8-6666-11e7-9a9d-48589adef618.png)

After:

![image](https://user-images.githubusercontent.com/447953/28076247-b0ff65de-6666-11e7-85a1-44307b83144a.png)


