### PR TITLE
Fix symbol splitting deprecation warning

### DIFF
--- a/lib/chewy/type/adapter/sequel.rb
+++ b/lib/chewy/type/adapter/sequel.rb
@@ -34,7 +34,7 @@ module Chewy
         end
 
         def full_column_name(column)
-          "#{target.table_name}__#{column}".to_sym
+          ::Sequel.qualify(target.table_name, column)
         end
 
         def all_scope


### PR DESCRIPTION
Sequel throws a warning due to symbol splitting, and suggests using `Sequel.qualify`
to get rid of it. Symbol splitting is deprecated and will be removed in Sequel 5.