### PR TITLE
Suppress request strategy log messages for every request

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -7,6 +7,7 @@ module Chewy
     class RequestStrategy
       def initialize(app)
         @app = app
+        Chewy.logger.debug("Chewy strategies stack: [1] <- #{Chewy.request_strategy}")
       end
 
       def call(env)

--- a/lib/chewy/strategy.rb
+++ b/lib/chewy/strategy.rb
@@ -54,14 +54,14 @@ module Chewy
 
     def push(name)
       result = @stack.push resolve(name).new
-      debug "[#{@stack.size}] <- #{current.name}"
+      debug "[#{@stack.size - 1}] <- #{current.name}" if @stack.size > 2
       result
     end
 
     def pop
       raise "Can't pop root strategy" if @stack.one?
-      debug "[#{@stack.size}] -> #{current.name}"
       result = @stack.pop.tap(&:leave)
+      debug "[#{@stack.size}] -> #{result.name}, now #{current.name}" if @stack.size > 1
       result
     end
 
@@ -77,7 +77,7 @@ module Chewy
     def debug(string)
       return unless Chewy.logger && Chewy.logger.debug?
       line = caller.detect { |l| l !~ %r{lib/chewy/strategy.rb:|lib/chewy.rb:} }
-      Chewy.logger.debug(["DEBUG: Chewy strategies stack: #{string}", line.sub(/:in\s.+$/, '')].join(' @ '))
+      Chewy.logger.debug(["Chewy strategies stack: #{string}", line.sub(/:in\s.+$/, '')].join(' @ '))
     end
 
     def resolve(name)


### PR DESCRIPTION
Right now all requests are being wrapped with `Chewy.strategy(Chewy.request_strategy) { @app.call(env) }`. So every request will have two log entries for default `Chewy.request_strategy`  added and removed from stack.
Here's what current log looks like:
```
Started GET "/articles" for 127.0.0.1 at 2017-07-22 20:25:44 +0300
DEBUG: Chewy strategies stack: [2] <- atomic @ **/chewy/lib/chewy/railtie.rb:17
Processing by ArticlesController#shared as HTML
  ArticlesIndex::Article Search (5.9ms) {:index=>["designs"], ***}
Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::JsonApi (2.3ms)
Completed 200 OK in 12ms (Views: 2.9ms | ActiveRecord: 0.0ms)
DEBUG: Chewy strategies stack: [2] -> atomic @ **/chewy/lib/chewy/railtie.rb:17
```
Since most developers are aware of their `Chewy.request_strategy` setting, there's no much need to remind them about it each time. So I decided to add a log message which will appear on server load (added to `railties.rb`). Also I've removed `DEBUG: ` portion of a message because it's quite obvious anyway, and it is a responsibility of `Logger::Formatter` to format logs.
This is what it looks like now:
```
# somewhere in server load log
=> Run `rails server -h` for more startup options
Chewy strategies stack: [1] <- atomic
```
For every request that doesn't change strategy, it will not show any strategy messages:
```
Started GET "/articles" for 127.0.0.1 at 2017-07-22 20:25:44 +0300
Processing by ArticlesController#shared as HTML
  ArticlesIndex::Article Search (5.9ms) {:index=>["articles"], ***}
Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::JsonApi (2.3ms)
Completed 200 OK in 12ms (Views: 2.9ms | ActiveRecord: 0.0ms)
```
 I have also added a `now` message when a strategy is removed from stack - that makes it much easier to follow strategy changes. And here's what happens if we wrap controller action with `Chewy.strategy(:bypass)` block:
```
Started GET "/articles" for 127.0.0.1 at 2017-07-22 20:25:44 +0300
Chewy strategies stack: [2] <- bypass @ **/app/controllers/articles_controller.rb:24
Processing by ArticlesController#shared as HTML
  ArticlesIndex::Article Search (5.9ms) {:index=>["articles"], ***}
Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::JsonApi (2.3ms)
Chewy strategies stack: [2] -> bypass, now atomic @ **/app/controllers/articles_controller.rb:24
Completed 200 OK in 12ms (Views: 2.9ms | ActiveRecord: 0.0ms)
```
That `now atomic` message shows which strategy will be used after bypass is removed from stack.

Please let me know if that makes sense.