### PR TITLE
Make sure Chewy logger is initialised

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -7,7 +7,7 @@ module Chewy
     class RequestStrategy
       def initialize(app)
         @app = app
-        Chewy.logger.debug("Chewy strategies stack: [1] <- #{Chewy.request_strategy}")
+        Chewy.logger.debug("Chewy strategies stack: [1] <- #{Chewy.request_strategy}") if Chewy.logger
       end
 
       def call(env)


### PR DESCRIPTION
Since the purpose of #543 was to reduce the strategy logging I thought this was the best solution imho without loosing the logging information and with my limited knowledge of the project.

If people with more experience of this project have better idea, I'm open for suggestions 😛 

Possible fix for #552 

cc: @pyromaniac, @Borzik 