### PR TITLE
Remove deprecation warning for ChewyObserve (sequel 4.45.0+)

### DIFF
--- a/lib/sequel/plugins/chewy_observe.rb
+++ b/lib/sequel/plugins/chewy_observe.rb
@@ -36,40 +36,25 @@ module Sequel
           callback_options = ChewyObserve.extract_callback_options!(args)
           update_proc = ChewyObserve.update_proc(type_name, *args, &block)
 
-          if Chewy.use_after_commit_callbacks
-            set_callback(:commit, callback_options, &update_proc)
-            set_callback(:destroy_commit, callback_options, &update_proc)
-          else
-            set_callback(:save, callback_options, &update_proc)
-            set_callback(:destroy, callback_options, &update_proc)
-          end
+          set_callback(:save, callback_options, &update_proc)
+          set_callback(:destroy, callback_options, &update_proc)
         end
       end
 
       # Instance level methods for Sequel::Model
       #
       module InstanceMethods
-        def after_commit
-          run_callbacks(:commit) do
-            super
-          end
-        end
-
-        def after_destroy_commit
-          run_callbacks(:destroy_commit) do
-            super
-          end
-        end
-
         def after_save
           run_callbacks(:save) do
             super
+            db.after_commit {} if Chewy.use_after_commit_callbacks
           end
         end
 
         def after_destroy
           run_callbacks(:destroy) do
             super
+            db.after_commit {} if Chewy.use_after_commit_callbacks
           end
         end
       end


### PR DESCRIPTION
http://sequel.jeremyevans.net/rdoc/files/doc/release_notes/4_45_0_txt.html