### PR TITLE
Wrapper: missed check in highlight method

### DIFF
--- a/lib/chewy/type/wrapper.rb
+++ b/lib/chewy/type/wrapper.rb
@@ -74,7 +74,7 @@ module Chewy
       end
 
       def highlight(attribute)
-        _data['highlight'][attribute].first
+        _data['highlight'][attribute].first if highlight?(attribute)
       end
 
       def highlight?(attribute)

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -36,6 +36,7 @@ describe Chewy::Query do
       specify { expect(subject.offset(6).count).to eq(3) }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name).to eq('Name3') }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlight).to eq('<em>Name3</em>') }
+      specify { expect(subject.query({}).highlight(fields: {name: {}}).first.name_highlight).to eq(nil) }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first._data['_source']['name']).to eq('Name3') }
       specify { expect(subject.types(:product).count).to eq(3) }
       specify { expect(subject.types(:product, :country).count).to eq(6) }


### PR DESCRIPTION
Hello, it is very helpful library! Thank you so much)

It seems you missed check with your own method in wrapper highlight method.
I'm not sure is it good practice or not to use elasticsearch without query or use it with wildcard, but in  this case we need to check that _data  contains key "highlights" and _data['highlights'] contains key which is equal to attribute name. 
Moreover - you already have this method!)

