### PR TITLE
Disconnect sequel databases before forking in parallel

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -155,6 +155,7 @@ module Chewy
             batches = adapter.import_references(*objects, routine.options.slice(:batch_size)).to_a
 
             ::ActiveRecord::Base.connection.close if defined?(::ActiveRecord::Base)
+            ::Sequel::DATABASES.each(&:disconnect) if defined?(::Sequel)
             results = ::Parallel.map_with_index(batches, routine.parallel_options, &IMPORT_WORKER.curry[self, routine.options, batches.size])
             ::ActiveRecord::Base.connection.reconnect! if defined?(::ActiveRecord::Base)
             errors, import, leftovers = process_parallel_import_results(results)


### PR DESCRIPTION
## Why
Much like `ActiveRecord`, `Sequel` cannot share a database connection between processes. Connections must be closed before forking a new process so that the new process will establish its own connection.

## How
Calls `#disconnect` on each connection `Sequel` holds. `Sequel` reconnects to the database before executing any query so there is no need to call `#reconnect` as there is with `ActiveRecord`.