### PR TITLE
Always ignore root in as_json to ignore include_root_in_json in AR

### DIFF
--- a/lib/chewy/fields/root.rb
+++ b/lib/chewy/fields/root.rb
@@ -69,7 +69,8 @@ module Chewy
       # @param object [Object] a base object for composition
       # @param crutches [Object] any object that will be passed to every field value proc as a last argument
       # @param fields [Array<Symbol>] a list of fields to compose, every field will be composed if empty
-      # @return [Hash] JSON-ready heash with stringifyed keys
+      # @return [Hash] JSON-ready hash with stringified keys
+      #
       def compose(object, crutches = nil, fields: [])
         result = evaluate([object, crutches])
 
@@ -84,9 +85,9 @@ module Chewy
             memo.merge!(field.compose(result, crutches) || {})
           end.as_json
         elsif fields.present?
-          result.as_json(only: fields)
+          result.as_json(only: fields, root: false)
         else
-          result.as_json
+          result.as_json(root: false)
         end
       end
 


### PR DESCRIPTION
We're porting the current Chewy version to ActiveSupport 3.2. (Official support was dropped, don't really know why - you just need to port pluck and stringify_keys from Rails 4 and that's almost all..).

But, in Rails 4 came option `ActiveRecord::Base.include_root_in_json = true`, with this configuration all `as_json` return root key. (Like it was default in Rails 3).
