### PR TITLE
Adding pipeline support to default_import_options

### DIFF
--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -14,7 +14,7 @@ require 'chewy/type/witchcraft'
 
 module Chewy
   class Type
-    IMPORT_OPTIONS_KEYS = %i[batch_size bulk_size refresh consistency replication raw_import journal].freeze
+    IMPORT_OPTIONS_KEYS = %i[batch_size bulk_size refresh consistency replication raw_import journal pipeline].freeze
 
     include Search
     include Mapping


### PR DESCRIPTION
Adding pipeline support to default_import_options for easier pipeline use in Type definition of Chewy Index.