### PR TITLE
Prevent mapping explosions in specification field

### DIFF
--- a/lib/chewy/index/specification.rb
+++ b/lib/chewy/index/specification.rb
@@ -35,8 +35,8 @@ module Chewy
       def locked
         filter = {ids: {values: [@index.derivable_name]}}
         document = Chewy::Stash::Specification.filter(filter).first
-        return {} unless document
-        document.specification || JSON.parse(document.value || '{}')
+        return '{}' unless document
+        document.specification || document.value || '{}'
       end
 
       # Simply returns `Chewy::Index.specification_hash`, but
@@ -46,14 +46,14 @@ module Chewy
       # @see Chewy::Index.specification_hash
       # @return [Hash] a JSON-ready hash
       def current
-        @index.specification_hash.as_json
+        JSON.dump(@index.specification_hash.as_json)
       end
 
       # Compares previously locked and current specifications.
       #
       # @return [true, false] the result of comparison
       def changed?
-        current != locked
+        JSON.parse(current) != JSON.parse(locked)
       end
     end
   end

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -11,7 +11,7 @@ module Chewy
       default_import_options journal: false
 
       field :value, index: 'no'
-      field :specification, type: 'object', enabled: false
+      field :specification, type: 'string', index: 'not_analyzed'
     end
 
     define_type :journal do # rubocop:disable Metrics/BlockLength

--- a/spec/chewy/index/specification_spec.rb
+++ b/spec/chewy/index/specification_spec.rb
@@ -59,10 +59,10 @@ describe Chewy::Index::Specification do
         '_type' => 'specification',
         '_id' => 'places',
         '_score' => 1.0,
-        '_source' => {'specification' => {
+        '_source' => {'specification' => JSON.dump(
           'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-        }, 'value' => nil}
+        ), 'value' => nil}
       }])
     end
 
@@ -70,75 +70,77 @@ describe Chewy::Index::Specification do
       before { specification1.lock! }
 
       specify do
-        expect { specification5.lock! }.to change { Chewy::Stash::Specification.all.hits }.to([{
-          '_index' => 'chewy_stash',
-          '_type' => 'specification',
-          '_id' => 'places',
-          '_score' => 1.0,
-          '_source' => {'specification' => {
-            'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
-            'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-          }, 'value' => nil}
-        }, {
-          '_index' => 'chewy_stash',
-          '_type' => 'specification',
-          '_id' => 'namespace/cities',
-          '_score' => 1.0,
-          '_source' => {'specification' => {
-            'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
-            'mappings' => {'city' => {'properties' => {'population' => {'type' => 'integer'}}}}
-          }, 'value' => nil}
-        }])
+        expect { specification5.lock! }.to change { Chewy::Stash::Specification.all.hits }.to([
+          {
+            '_index' => 'chewy_stash',
+            '_type' => 'specification',
+            '_id' => 'places',
+            '_score' => 1.0,
+            '_source' => {
+              'value' => nil,
+              'specification' => "{\"settings\":{\"index\":{\"number_of_shards\":1,\"number_of_replicas\":0}},\"mappings\":{\"city\":{\"properties\":{\"name\":{\"type\":\"string\"}}}}}"
+            }
+          }, {
+            '_index' => 'chewy_stash',
+            '_type' => 'specification',
+            '_id' => 'namespace/cities',
+            '_score' => 1.0,
+            '_source' => {
+              'value' => nil,
+              'specification' => "{\"settings\":{\"index\":{\"number_of_shards\":1,\"number_of_replicas\":0}},\"mappings\":{\"city\":{\"properties\":{\"population\":{\"type\":\"integer\"}}}}}"
+            }
+          }
+        ])
       end
     end
   end
 
   describe '#locked' do
     specify do
-      expect { specification1.lock! }.to change { specification1.locked }.from({}).to(
+      expect { specification1.lock! }.to change { specification1.locked }.from('{}').to(JSON.dump(
         'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
         'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-      )
+      ))
     end
 
     specify do
-      expect { specification5.lock! }.to change { specification5.locked }.from({}).to(
+      expect { specification5.lock! }.to change { specification5.locked }.from('{}').to(JSON.dump(
         'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
         'mappings' => {'city' => {'properties' => {'population' => {'type' => 'integer'}}}}
-      )
+      ))
     end
 
     context do
       before { specification1.lock! }
 
       specify do
-        expect { specification2.lock! }.to change { specification2.locked }.from(
+        expect { specification2.lock! }.to change { specification2.locked }.from(JSON.dump(
           'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-        ).to(
+        )).to(JSON.dump(
           'settings' => {'analyzer' => {}, 'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-        )
+        ))
       end
 
       specify do
-        expect { specification3.lock! }.to change { specification3.locked }.from(
+        expect { specification3.lock! }.to change { specification3.locked }.from(JSON.dump(
           'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-        ).to(
+        )).to(JSON.dump(
           'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}, 'population' => {'type' => 'integer'}}}}
-        )
+        ))
       end
     end
   end
 
   describe '#current' do
     specify do
-      expect(specification2.current).to eq(
-        'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}},
-        'settings' => {'analyzer' => {}, 'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}}
-      )
+      expect(specification2.current).to eq(JSON.dump(
+        'settings' => {'analyzer' => {}, 'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
+        'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
+      ))
     end
   end
 

--- a/spec/chewy/type/adapter/active_record_spec.rb
+++ b/spec/chewy/type/adapter/active_record_spec.rb
@@ -454,9 +454,9 @@ describe Chewy::Type::Adapter::ActiveRecord, :active_record do
       specify do
         expect(subject.import_fields(fields: [:updated_at], typecast: false))
           .to match([contain_exactly(
-            [1, match(/#{Time.now.strftime('%Y-%m-%d')}/)],
-            [2, match(/#{Time.now.strftime('%Y-%m-%d')}/)],
-            [3, match(/#{Time.now.strftime('%Y-%m-%d')}/)]
+            [1, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)],
+            [2, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)],
+            [3, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)]
           )])
       end
     end


### PR DESCRIPTION
change specification field type to string in order to prevent issues.
Related issue #595 