### PR TITLE
Avoid Elasticsearch index updates when passing empty reflections

### DIFF
--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -126,6 +126,7 @@ module Chewy
       private
 
         def import_routine(*args)
+          return if args.first.blank? && !args.first.nil?
           routine = Routine.new(self, args.extract_options!)
           routine.create_indexes!
 

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -40,6 +40,12 @@ describe Chewy::Type::Import do
       CitiesIndex::City.import(dummy_city)
     end
 
+    specify 'lazy without objects' do
+      expect(CitiesIndex).not_to receive(:exists?)
+      expect(CitiesIndex).not_to receive(:create!)
+      CitiesIndex::City.import([])
+    end
+
     context 'skip' do
       before do
         # To avoid flaky issues when previous specs were run


### PR DESCRIPTION
Passing `[]` or another equivalent of an empty reflection to `Index.import!` makes two requests to the corresponding Elasticsearch index. `GET /index` and `PUT /index` to ensure whether the index exists, and to update the index.

Given a complicated record which triggers many Chewy index updates on associations, this might result in N+1 requests, which might be undesired.

This change adds avoids these requests whenever the reflection is empty.