### PR TITLE
(WIP) Adapt to Elatic Search v6 changes

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -82,7 +82,7 @@ module Chewy
       @disable_refresh_async = false
       @indices_path = 'app/chewy'
       @default_root_options = {}
-      @default_field_type = 'string'.freeze
+      @default_field_type = 'keyword'.freeze
       self.search_class = Chewy::Search::Request
     end
 

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -10,17 +10,17 @@ module Chewy
     define_type :specification do
       default_import_options journal: false
 
-      field :value, index: 'no'
+      field :value
       field :specification, type: 'object', enabled: false
     end
 
     define_type :journal do # rubocop:disable Metrics/BlockLength
       default_import_options journal: false
 
-      field :index_name, type: 'string', index: 'not_analyzed'
-      field :type_name, type: 'string', index: 'not_analyzed'
-      field :action, type: 'string', index: 'not_analyzed'
-      field :references, type: 'string', index: 'no'
+      field :index_name
+      field :type_name
+      field :action
+      field :references
       field :created_at, type: 'date'
 
       # Loads all entries since the specified time.


### PR DESCRIPTION
- 'string' field type does not exist anymore. Changing
default_field_type to 'keyword'.
- Field property 'index' now receives a boolean. Keyword type is not
analyzed by default, so no need to specify explicitly.

@pyromaniac This still is not finished. The Journal index creation errors out about multi-index:
```
Elasticsearch::Transport::Transport::Errors::BadRequest: [400] {"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[instance-some_id][some_ip][indices:admin/create]"}],"type":"illegal_argument_exception","reason":"Rejecting mapping update to [dev_chewy_stash] as the final mapping would have more than 1 type: [journal, specification]"},"status":400}
```
I am stuck there.

Also related, when resetting an index, even if I configure `journal: false` on settings, Chewy is trying to create the Journal index. I think it should not create it, as it is not going to be used if `journal: true`. Should be created on first use if not exists.