### PR TITLE
Improve performance of bypassing

### DIFF
--- a/lib/chewy/type/observe.rb
+++ b/lib/chewy/type/observe.rb
@@ -9,14 +9,6 @@ module Chewy
           method = args.first
 
           proc do
-            backreference = if method && method.to_s == 'self'
-              self
-            elsif method
-              send(method)
-            else
-              instance_eval(&block)
-            end
-
             reference = if type_name.is_a?(Proc)
               if type_name.arity.zero?
                 instance_exec(&type_name)
@@ -27,7 +19,19 @@ module Chewy
               type_name
             end
 
-            Chewy.derive_type(reference).update_index(backreference, options)
+            type = Chewy.derive_type(reference)
+
+            next if Chewy.strategy.current.name == :bypass
+
+            backreference = if method && method.to_s == 'self'
+              self
+            elsif method
+              send(method)
+            else
+              instance_eval(&block)
+            end
+
+            type.update_index(backreference, options)
           end
         end
 


### PR DESCRIPTION
It makes sense to short-circuit Chewy's `update_proc` when current strategy is `bypass`.

Currently, even when current strategy is to bypass ES, Chewy still takes time to evaluate the backreference (which is an AR relation, usually).

It's better to skip it as it affects the performance of an application.

Why not put `next if ...` in the beginning of the proc?

Because `Chewy.derive_type` may cause some chewy types to load, if Rails' `eager_load` is `false`. If we stop calling `Chewy.derive_type`, this can cause undesired behavior and bugs, which actually happened in one of the applications I work on. So, in order to preserve existing behavior, we call `derive_type` _before_ `next if`, and the remaining part after the `next if ...`. The remaining part is the heaviest one performance-wise, anyway.