### PR TITLE
Rails::VERSION is more accurate check for presence of Rails

### DIFF
--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -155,7 +155,7 @@ module Chewy
 
     def yaml_settings
       @yaml_settings ||= begin
-        if defined?(Rails)
+        if defined?(Rails::VERSION)
           file = Rails.root.join('config', 'chewy.yml')
 
           if File.exist?(file)

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -137,5 +137,21 @@ describe Chewy::Config do
     specify do
       expect(subject.configuration).to include(indices_path: 'app/custom_indices_path')
     end
+
+    context 'when Rails::VERSION constant is defined' do
+      it 'looks for configuration in "config/chewy.yml"' do
+        module Rails
+          VERSION = '5.1.0'.freeze
+
+          def self.root
+            Pathname.new(__dir__)
+          end
+        end
+
+        expect(File).to receive(:exist?)
+          .with(Pathname.new(__dir__).join('config', 'chewy.yml'))
+        subject.configuration
+      end
+    end
   end
 end


### PR DESCRIPTION
`Rails` module can be defined without actual Rails gem.

I work on a Sinatra project, which has [ActionView](https://github.com/rails/rails/tree/master/actionview) in dependencies. `ActionView` itself does not depend on Rails, but it has [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer/blob/master/lib/rails/html/sanitizer.rb#L1) and [rails-dom-testing](https://github.com/rails/rails-dom-testing/blob/master/lib/rails/dom/testing/assertions.rb#L4) gems in dependencies, which both define `Rails` module.

Therefore, check `defined?(Rails)` isn't fully valid, and requires hacking on the client app side to make it work (i.e. defining `Rails.root` method and having `config/chewy.yml` file)