### PR TITLE
Do not underscore suggested index name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+  * Do not underscore suggested index name on `Chewy::Index.index_name` call.
   * It is possible now to call `root` method several times inside a single type definition, the options will be merged. Also, the block isn't required anymore.
 
 # Version 0.10.1

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -52,7 +52,7 @@ module Chewy
       #   @return [String] result index name
       def index_name(suggest = nil, prefix: nil, suffix: nil)
         if suggest
-          @base_name = suggest.to_s.underscore.presence
+          @base_name = suggest.to_s.presence
         else
           [
             prefix || prefix_with_deprecation,


### PR DESCRIPTION
to allow legacy names without modifications

actual problem:
we wanna using`chewy` DSL just for querying the data at first
and our legacy name contains some dash symbols
