### PR TITLE
Split stash onto two indices and make it support ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,9 +986,9 @@ rake chewy:reset[-users,places] # resets every index in the application except s
 
 Performs reset exactly the same way as `chewy:reset` does, but only when the index specification (setting or mapping) was changed.
 
-It works only when index specification is locked in `Chewy::Stash` index. The first run will reset all indexes and lock their specifications.
+It works only when index specification is locked in `Chewy::Stash::Specification` index. The first run will reset all indexes and lock their specifications.
 
-See [Chewy::Stash](lib/chewy/stash.rb) and [Chewy::Index::Specification](lib/chewy/index/specification.rb) for more details.
+See [Chewy::Stash::Specification](lib/chewy/stash.rb) and [Chewy::Index::Specification](lib/chewy/index/specification.rb) for more details.
 
 
 ```bash

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -17,6 +17,7 @@ require 'active_support/core_ext/string/inflections'
 require 'i18n/core_ext/hash'
 require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
 require 'singleton'
+require 'base64'
 
 require 'elasticsearch'
 

--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -33,6 +33,13 @@ module Chewy
           end
         mapping.reverse_merge!(options)
         mapping.reverse_merge!(type: (children.present? ? 'object' : Chewy.default_field_type))
+
+        # This is done to support ES2 journaling and will be removed soon
+        if mapping[:type] == 'keyword' && Chewy::Runtime.version < '5.0'
+          mapping[:type] = 'string'
+          mapping[:index] = 'not_analyzed'
+        end
+
         {name => mapping}
       end
 

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -57,14 +57,9 @@ module Chewy
           general_name = index_name
           suffixed_name = index_name(suffix: suffix)
 
-          if Chewy::Runtime.version >= 1.1
-            body = specification_hash
-            body[:aliases] = {general_name => {}} if options[:alias] && suffixed_name != general_name
-            result = client.indices.create(index: suffixed_name, body: body)
-          else
-            result = client.indices.create(index: suffixed_name, body: specification_hash)
-            result &&= client.indices.put_alias(index: suffixed_name, name: general_name) if options[:alias] && name != index_name
-          end
+          body = specification_hash
+          body[:aliases] = {general_name => {}} if options[:alias] && suffixed_name != general_name
+          result = client.indices.create(index: suffixed_name, body: body)
 
           Chewy.wait_for_status if result
           result
@@ -145,7 +140,7 @@ module Chewy
               if args.one? && type_names.one?
                 objects = {type_names.first.to_sym => args.first}
               elsif args.one?
-                fail ArgumentError, "Plase pass objects for `#{method}` as a hash with type names"
+                fail ArgumentError, "Please pass objects for `#{method}` as a hash with type names"
               else
                 objects = options.reject { |k, v| !type_names.map(&:to_sym).include?(k) }
               end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -140,8 +140,15 @@ module Chewy
         #
         %i[import import!].each do |method|
           class_eval <<-METHOD, __FILE__, __LINE__ + 1
-            def #{method} options = {}
-              objects = options.reject { |k, v| !type_names.map(&:to_sym).include?(k) }
+            def #{method}(*args)
+              options = args.extract_options!
+              if args.one? && type_names.one?
+                objects = {type_names.first.to_sym => args.first}
+              elsif args.one?
+                fail ArgumentError, "Plase pass objects for `#{method}` as a hash with type names"
+              else
+                objects = options.reject { |k, v| !type_names.map(&:to_sym).include?(k) }
+              end
               types.map do |type|
                 args = [objects[type.type_name.to_sym], options.dup].reject(&:blank?)
                 type.#{method} *args

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -196,12 +196,12 @@ module Chewy
       end
 
       # Eager loads and returns all the indexes defined in the application
-      # except the Chewy::Stash.
+      # except Chewy::Stash::Specification and Chewy::Stash::Journal.
       #
       # @return [Array<Chewy::Index>] indexes found
       def all_indexes
         Chewy.eager_load!
-        Chewy::Index.descendants - [Chewy::Stash]
+        Chewy::Index.descendants - [Chewy::Stash::Journal, Chewy::Stash::Specification]
       end
 
       def normalize_indexes(*identifiers)

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -1,27 +1,24 @@
 module Chewy
   # This class is the main storage for Chewy service data,
-  # Now index raw specifications are stored in the `chewy_stash`
-  # index. In the future the journal will be moved here as well.
+  # Now index raw specifications are stored in the `chewy_specifications`
+  # index.
+  # Journal entries are stored in `chewy_journal`
   #
   # @see Chewy::Index::Specification
-  class Stash < Chewy::Index
-    index_name 'chewy_stash'
+  module Stash
+    class Specification < Chewy::Index
+      index_name 'chewy_specifications'
 
-    define_type :specification do
-      default_import_options journal: false
+      define_type :specification do
+        default_import_options journal: false
 
-      field :value, index: 'no'
-      field :specification, type: 'object', enabled: false
+        field :value, index: 'no'
+        field :specification, type: 'object', enabled: false
+      end
     end
 
-    define_type :journal do # rubocop:disable Metrics/BlockLength
-      default_import_options journal: false
-
-      field :index_name, type: 'string', index: 'not_analyzed'
-      field :type_name, type: 'string', index: 'not_analyzed'
-      field :action, type: 'string', index: 'not_analyzed'
-      field :references, type: 'string', index: 'no'
-      field :created_at, type: 'date'
+    class Journal < Chewy::Index
+      index_name 'chewy_journal'
 
       # Loads all entries since the specified time.
       #
@@ -59,12 +56,22 @@ module Chewy
         scope
       end
 
-      def type
-        @type ||= Chewy.derive_type("#{index_name}##{type_name}")
-      end
+      define_type :journal do
+        default_import_options journal: false
 
-      def references
-        @references ||= Array.wrap(@attributes['references']).map { |r| JSON.load(r) } # rubocop:disable Security/JSONLoad
+        field :index_name, type: 'string', index: 'not_analyzed'
+        field :type_name, type: 'string', index: 'not_analyzed'
+        field :action, type: 'string', index: 'not_analyzed'
+        field :references, type: 'string', index: 'no'
+        field :created_at, type: 'date'
+
+        def type
+          @type ||= Chewy.derive_type("#{index_name}##{type_name}")
+        end
+
+        def references
+          @references ||= Array.wrap(@attributes['references']).map { |r| JSON.load(r) } # rubocop:disable Security/JSONLoad
+        end
       end
     end
   end

--- a/lib/chewy/type/import/journal_builder.rb
+++ b/lib/chewy/type/import/journal_builder.rb
@@ -10,7 +10,7 @@ module Chewy
 
         def bulk_body
           Chewy::Type::Import::BulkBuilder.new(
-            Chewy::Stash::Journal,
+            Chewy::Stash::Journal::Journal,
             index: [
               entries(:index, @index),
               entries(:delete, @delete)
@@ -18,7 +18,7 @@ module Chewy
           ).bulk_body.each do |item|
             item.values.first.merge!(
               _index: Chewy::Stash::Journal.index_name,
-              _type: Chewy::Stash::Journal.type_name
+              _type: Chewy::Stash::Journal::Journal.type_name
             )
           end
         end

--- a/lib/chewy/type/import/journal_builder.rb
+++ b/lib/chewy/type/import/journal_builder.rb
@@ -31,7 +31,7 @@ module Chewy
             index_name: @type.index.derivable_name,
             type_name: @type.type_name,
             action: action,
-            references: identify(objects).map(&:to_json),
+            references: identify(objects).map(&:to_json).map(&Base64.method(:encode64)),
             created_at: Time.now.utc
           }
         end

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -64,7 +64,7 @@ module Chewy
         # Creates the journal index and the type corresponding index if necessary.
         # @return [Object] whatever
         def create_indexes!
-          Chewy::Stash.create if @options[:journal]
+          Chewy::Stash::Journal.create if @options[:journal]
           return if Chewy.configuration[:skip_index_creation_on_import]
           @type.index.create!(@bulk_options.slice(:suffix)) unless @type.index.exists?
         end

--- a/spec/chewy/index/specification_spec.rb
+++ b/spec/chewy/index/specification_spec.rb
@@ -55,7 +55,7 @@ describe Chewy::Index::Specification do
   describe '#lock!' do
     specify do
       expect { specification1.lock! }.to change { Chewy::Stash::Specification.all.hits }.from([]).to([{
-        '_index' => 'chewy_stash',
+        '_index' => 'chewy_specifications',
         '_type' => 'specification',
         '_id' => 'places',
         '_score' => 1.0,
@@ -71,7 +71,7 @@ describe Chewy::Index::Specification do
 
       specify do
         expect { specification5.lock! }.to change { Chewy::Stash::Specification.all.hits }.to([{
-          '_index' => 'chewy_stash',
+          '_index' => 'chewy_specifications',
           '_type' => 'specification',
           '_id' => 'places',
           '_score' => 1.0,
@@ -80,7 +80,7 @@ describe Chewy::Index::Specification do
             'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
           }, 'value' => nil}
         }, {
-          '_index' => 'chewy_stash',
+          '_index' => 'chewy_specifications',
           '_type' => 'specification',
           '_id' => 'namespace/cities',
           '_score' => 1.0,

--- a/spec/chewy/index/specification_spec.rb
+++ b/spec/chewy/index/specification_spec.rb
@@ -59,10 +59,10 @@ describe Chewy::Index::Specification do
         '_type' => 'specification',
         '_id' => 'places',
         '_score' => 1.0,
-        '_source' => {'specification' => {
+        '_source' => {'specification' => Base64.encode64({
           'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
           'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-        }, 'value' => nil}
+        }.to_json)}
       }])
     end
 
@@ -75,19 +75,19 @@ describe Chewy::Index::Specification do
           '_type' => 'specification',
           '_id' => 'places',
           '_score' => 1.0,
-          '_source' => {'specification' => {
+          '_source' => {'specification' => Base64.encode64({
             'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
             'mappings' => {'city' => {'properties' => {'name' => {'type' => 'string'}}}}
-          }, 'value' => nil}
+          }.to_json)}
         }, {
           '_index' => 'chewy_specifications',
           '_type' => 'specification',
           '_id' => 'namespace/cities',
           '_score' => 1.0,
-          '_source' => {'specification' => {
+          '_source' => {'specification' => Base64.encode64({
             'settings' => {'index' => {'number_of_shards' => 1, 'number_of_replicas' => 0}},
             'mappings' => {'city' => {'properties' => {'population' => {'type' => 'integer'}}}}
-          }, 'value' => nil}
+          }.to_json)}
         }])
       end
     end

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -51,7 +51,7 @@ describe Chewy::Journal do
 
             places_index.import
 
-            expect(Chewy::Stash.exists?).to eq true
+            expect(Chewy::Stash::Journal.exists?).to eq true
 
             Timecop.freeze(update_time)
             cities.first.update_attributes!(name: 'Supername')
@@ -231,7 +231,7 @@ describe Chewy::Journal do
           let!(:journal_entries) do
             record = Chewy::Stash::Journal.entries(time).first
             Array.new(count_of_checks) do |i|
-              Chewy::Stash::Journal.new(
+              Chewy::Stash::Journal::Journal.new(
                 record.attributes.merge(
                   'created_at' => time.to_i + i,
                   'references' => [i.to_s]

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -65,63 +65,63 @@ describe Chewy::Journal do
                 'index_name' => "#{namespace}places",
                 'type_name' => 'city',
                 'action' => 'index',
-                'references' => ['1'],
+                'references' => ['1'].map(&Base64.method(:encode64)),
                 'created_at' => time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'city',
                 'action' => 'index',
-                'references' => ['2'],
+                'references' => ['2'].map(&Base64.method(:encode64)),
                 'created_at' => time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'country',
                 'action' => 'index',
-                'references' => ['1'],
+                'references' => ['1'].map(&Base64.method(:encode64)),
                 'created_at' => time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'country',
                 'action' => 'index',
-                'references' => ['2'],
+                'references' => ['2'].map(&Base64.method(:encode64)),
                 'created_at' => time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'country',
                 'action' => 'index',
-                'references' => ['3'],
+                'references' => ['3'].map(&Base64.method(:encode64)),
                 'created_at' => time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'city',
                 'action' => 'index',
-                'references' => %w[1 2],
+                'references' => %w[1 2].map(&Base64.method(:encode64)),
                 'created_at' => import_time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'country',
                 'action' => 'index',
-                'references' => %w[1 2 3],
+                'references' => %w[1 2 3].map(&Base64.method(:encode64)),
                 'created_at' => import_time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'city',
                 'action' => 'index',
-                'references' => ['1'],
+                'references' => ['1'].map(&Base64.method(:encode64)),
                 'created_at' => update_time.utc.as_json
               },
               {
                 'index_name' => "#{namespace}places",
                 'type_name' => 'country',
                 'action' => 'delete',
-                'references' => ['2'],
+                'references' => ['2'].map(&Base64.method(:encode64)),
                 'created_at' => destroy_time.utc.as_json
               }
             ]

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -23,8 +23,21 @@ describe Chewy::RakeHelper, :orm do
   let!(:countries) { Array.new(2) { |i| Country.create!(name: "Name#{i + 1}") } }
   let(:journal) do
     Chewy::Stash::Journal.import([
-      {index_name: 'places', type_name: 'city', action: 'index', references: cities.first(2).map(&:id).map(&:to_s).map(&:to_json), created_at: 2.minutes.since},
-      {index_name: 'places', type_name: 'country', action: 'index', references: [countries.first.id.to_s.to_json], created_at: 4.minutes.since}
+      {
+        index_name: 'places',
+        type_name: 'city',
+        action: 'index',
+        references: cities.first(2).map(&:id).map(&:to_s)
+                      .map(&:to_json).map(&Base64.method(:encode64)),
+        created_at: 2.minutes.since
+      },
+      {
+        index_name: 'places',
+        type_name: 'country',
+        action: 'index',
+        references: [Base64.encode64(countries.first.id.to_s.to_json)],
+        created_at: 4.minutes.since
+      }
     ])
   end
 

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -42,9 +42,9 @@ describe Chewy::RakeHelper, :orm do
   Applying journal to \\[PlacesIndex::City, PlacesIndex::Country\\], 3 entries, stage 1
   Imported PlacesIndex::City in \\d+s, stats: index 2
   Imported PlacesIndex::Country in \\d+s, stats: index 1
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Resetting UsersIndex
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
       OUTPUT
     end
@@ -60,7 +60,7 @@ Total: \\d+s\\Z
   Applying journal to \\[PlacesIndex::City, PlacesIndex::Country\\], 3 entries, stage 1
   Imported PlacesIndex::City in \\d+s, stats: index 2
   Imported PlacesIndex::Country in \\d+s, stats: index 1
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
       OUTPUT
     end
@@ -71,7 +71,7 @@ Total: \\d+s\\Z
         .not_to update_index(PlacesIndex::City)
       expect(output.string).to match(Regexp.new(<<-OUTPUT, Regexp::MULTILINE))
 \\AResetting UsersIndex
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
       OUTPUT
     end
@@ -86,9 +86,9 @@ Total: \\d+s\\Z
 \\AResetting PlacesIndex
   Imported PlacesIndex::City in \\d+s, stats: index 3
   Imported PlacesIndex::Country in \\d+s, stats: index 2
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Resetting UsersIndex
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
       OUTPUT
     end
@@ -103,7 +103,7 @@ Total: \\d+s\\Z
         expect(output.string).to match(Regexp.new(<<-OUTPUT, Regexp::MULTILINE))
 \\ASkipping PlacesIndex, the specification didn't change
 Resetting UsersIndex
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
         OUTPUT
       end
@@ -114,7 +114,7 @@ Total: \\d+s\\Z
           .not_to update_index(PlacesIndex::City)
         expect(output.string).to match(Regexp.new(<<-OUTPUT, Regexp::MULTILINE))
 \\AResetting UsersIndex
-  Imported Chewy::Stash::Specification in \\d+s, stats: index 1
+  Imported Chewy::Stash::Specification::Specification in \\d+s, stats: index 1
 Total: \\d+s\\Z
         OUTPUT
       end

--- a/spec/chewy/stash_spec.rb
+++ b/spec/chewy/stash_spec.rb
@@ -83,7 +83,7 @@ describe Chewy::Stash::Journal, :orm do
   describe '#type' do
     let(:index_name) { 'users' }
     let(:type_name) { 'city' }
-    subject { described_class.new('index_name' => index_name, 'type_name' => type_name).type }
+    subject { described_class::Journal.new('index_name' => index_name, 'type_name' => type_name).type }
 
     specify { expect { subject }.to raise_error(Chewy::UnderivableType) }
 

--- a/spec/chewy/type/import/journal_builder_spec.rb
+++ b/spec/chewy/type/import/journal_builder_spec.rb
@@ -32,7 +32,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
               'index_name' => 'namespace/places',
               'type_name' => 'city',
               'action' => 'index',
-              'references' => ['{"id":1,"name":"City"}'],
+              'references' => [Base64.encode64('{"id":1,"name":"City"}')],
               'created_at' => time.as_json
             }
           }
@@ -51,7 +51,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
               'index_name' => 'namespace/places',
               'type_name' => 'city',
               'action' => 'delete',
-              'references' => ['{"id":1,"name":"City"}'],
+              'references' => [Base64.encode64('{"id":1,"name":"City"}')],
               'created_at' => time.as_json
             }
           }
@@ -72,7 +72,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
               'index_name' => 'namespace/places',
               'type_name' => 'country',
               'action' => 'index',
-              'references' => ['1'],
+              'references' => [Base64.encode64('1')],
               'created_at' => time.as_json
             }
           }
@@ -84,7 +84,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
               'index_name' => 'namespace/places',
               'type_name' => 'country',
               'action' => 'delete',
-              'references' => ['2'],
+              'references' => [Base64.encode64('2')],
               'created_at' => time.as_json
             }
           }

--- a/spec/chewy/type/import/journal_builder_spec.rb
+++ b/spec/chewy/type/import/journal_builder_spec.rb
@@ -26,7 +26,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
       specify do
         expect(subject.bulk_body).to eq([{
           index: {
-            _index: 'chewy_stash',
+            _index: 'chewy_journal',
             _type: 'journal',
             data: {
               'index_name' => 'namespace/places',
@@ -45,7 +45,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
       specify do
         expect(subject.bulk_body).to eq([{
           index: {
-            _index: 'chewy_stash',
+            _index: 'chewy_journal',
             _type: 'journal',
             data: {
               'index_name' => 'namespace/places',
@@ -66,7 +66,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
       specify do
         expect(subject.bulk_body).to eq([{
           index: {
-            _index: 'chewy_stash',
+            _index: 'chewy_journal',
             _type: 'journal',
             data: {
               'index_name' => 'namespace/places',
@@ -78,7 +78,7 @@ describe Chewy::Type::Import::JournalBuilder, :orm do
           }
         }, {
           index: {
-            _index: 'chewy_stash',
+            _index: 'chewy_journal',
             _type: 'journal',
             data: {
               'index_name' => 'namespace/places',


### PR DESCRIPTION
In order to support ES6 we have to split an index with 2 types onto two singe-types indices.
Also, `string` type is not supported, so we use `keyword` with ES2 fallback.
Also, we want to store an unlimited amount of data in specifications because there are guys facing the limits. String data types are limited to several kb of data or so, object fields are limited to 1000 keys by default on a single level. So binary field is the only way to go.