### PR TITLE
fix typo var data -> _data

### DIFF
--- a/lib/chewy/type/wrapper.rb
+++ b/lib/chewy/type/wrapper.rb
@@ -41,7 +41,7 @@ module Chewy
 
       %w[_id _type _index].each do |name|
         define_method name do
-          data[name]
+          _data[name]
         end
       end
 


### PR DESCRIPTION
fix typo variable from getting _id,_index,_type