### PR TITLE
Add support for direct_import parameter to skip loading default scope on import

### DIFF
--- a/lib/chewy/type/adapter/orm.rb
+++ b/lib/chewy/type/adapter/orm.rb
@@ -118,7 +118,6 @@ module Chewy
           hash = Hash[collection_ids.map(&:to_s).zip(collection)]
 
           indexed = collection_ids.each_slice(options[:batch_size]).map do |ids|
-
             batch = if options[:raw_import]
               raw_default_scope_where_ids_in(ids, options[:raw_import])
             elsif options[:direct_import]

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -67,6 +67,7 @@ module Chewy
         # @option options [String] suffix an index name suffix, used for zero-downtime reset mostly, no suffix by default
         # @option options [Integer] bulk_size bulk API chunk size in bytes; if passed, the request is performed several times for each chunk, empty by default
         # @option options [Integer] batch_size passed to the adapter import method, used to split imported objects in chunks, 1000 by default
+        # @option options [Boolean] direct_import passed to the adapter import method, used skip the collection reload
         # @option options [true, false] journal enables imported objects journaling, false by default
         # @option options [Array<Symbol, String>] update_fields list of fields for the partial import, empty by default
         # @option options [true, false] update_failover enables full objects reimport in cases of partial update errors, `true` by default


### PR DESCRIPTION
Proof of Concept to get around issue outlined in #636. 

Currently there's no tests, as I wasn't sure how the spec files were structured for this project. I can add the specs if someone could point me to an example where I could exercise the functionality of importing objects with extra includes.