### PR TITLE
Add query string parameter support

### DIFF
--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -10,7 +10,7 @@ module Chewy
     # @see Chewy::Search::Request#parameters
     # @see Chewy::Search::Parameters::Storage
     class Parameters
-      QUERY_STRING_PARAMS = %i[search_type request_cache].freeze
+      QUERY_STRING_PARAMS = %i[search_type request_cache allow_partial_search_results].freeze
       # Default storage classes warehouse. It is probably possible to
       # add your own classes here if necessary, but I'm not sure it will work.
       #

--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -10,6 +10,7 @@ module Chewy
     # @see Chewy::Search::Request#parameters
     # @see Chewy::Search::Parameters::Storage
     class Parameters
+      QUERY_STRING_PARAMS = %i[search_type request_cache].freeze
       # Default storage classes warehouse. It is probably possible to
       # add your own classes here if necessary, but I'm not sure it will work.
       #
@@ -101,11 +102,7 @@ module Chewy
       #
       # @return [Hash] request body
       def render
-        body = @storages.except(:filter, :query, :none).values.inject({}) do |result, storage|
-          result.merge!(storage.render || {})
-        end
-        body.merge!(render_query || {})
-        body.present? ? {body: body} : {}
+        {}.merge(render_body).merge(render_query_string_params)
       end
 
     protected
@@ -124,6 +121,22 @@ module Chewy
         names = names.map(&:to_sym)
         self.class.storages.values_at(*names)
         names
+      end
+
+      def render_query_string_params
+        stores = @storages.select { |storage_name, _| QUERY_STRING_PARAMS.include?(storage_name) }
+        stores.values.inject({}) do |result, storage|
+          result.merge!(storage.render || {})
+        end
+      end
+
+      def render_body
+        exceptions = %i[filter query none] + QUERY_STRING_PARAMS
+        body = @storages.except(*exceptions).values.inject({}) do |result, storage|
+          result.merge!(storage.render || {})
+        end
+        body.merge!(render_query || {})
+        body.present? ? {body: body} : {}
       end
 
       def render_query

--- a/lib/chewy/search/parameters/allow_partial_search_results.rb
+++ b/lib/chewy/search/parameters/allow_partial_search_results.rb
@@ -1,0 +1,27 @@
+require 'chewy/search/parameters/storage'
+
+module Chewy
+  module Search
+    class Parameters
+      # Stores boolean value, but has 3 states: `true`, `false` and `nil`.
+      #
+      # @see Chewy::Search::Request#allow_partial_search_results
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/6.4/search-request-body.html#_parameters_4
+      class AllowPartialSearchResults < Storage
+        # We don't want to render `nil`, but render `true` and `false` values.
+        #
+        # @see Chewy::Search::Parameters::Storage#render
+        # @return [{Symbol => Object}, nil]
+        def render
+          {self.class.param_name => value} unless value.nil?
+        end
+
+      private
+
+        def normalize(value)
+          !!value unless value.nil?
+        end
+      end
+    end
+  end
+end

--- a/spec/chewy/search/parameters_spec.rb
+++ b/spec/chewy/search/parameters_spec.rb
@@ -113,6 +113,11 @@ describe Chewy::Search::Parameters do
     end
 
     context do
+      subject { described_class.new(allow_partial_search_results: true) }
+      specify { expect(subject.render).to eq(allow_partial_search_results: true) }
+    end
+
+    context do
       subject { described_class.new(query: {foo: 'bar'}, filter: {moo: 'baz'}) }
       specify { expect(subject.render).to eq(body: {query: {bool: {must: {foo: 'bar'}, filter: {moo: 'baz'}}}}) }
     end

--- a/spec/chewy/search/parameters_spec.rb
+++ b/spec/chewy/search/parameters_spec.rb
@@ -103,6 +103,16 @@ describe Chewy::Search::Parameters do
     specify { expect(described_class.new.render).to eq({}) }
 
     context do
+      subject { described_class.new(request_cache: true) }
+      specify { expect(subject.render).to eq(request_cache: true) }
+    end
+
+    context do
+      subject { described_class.new(search_type: 'query_then_fetch') }
+      specify { expect(subject.render).to eq(search_type: 'query_then_fetch') }
+    end
+
+    context do
       subject { described_class.new(query: {foo: 'bar'}, filter: {moo: 'baz'}) }
       specify { expect(subject.render).to eq(body: {query: {bool: {must: {foo: 'bar'}, filter: {moo: 'baz'}}}}) }
     end

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -151,13 +151,20 @@ describe Chewy::Search::Request do
   end
 
   describe '#request_cache' do
-    specify { expect(subject.request_cache(true).render[:body]).to include(request_cache: true) }
-    specify { expect(subject.request_cache(true).request_cache(false).render[:body]).to include(request_cache: false) }
-    specify { expect(subject.request_cache(true).request_cache(nil).render[:body]).to be_blank }
+    specify { expect(subject.request_cache(true).render).to include(request_cache: true) }
+    specify { expect(subject.request_cache(true).request_cache(false).render).to include(request_cache: false) }
+    specify { expect(subject.request_cache(true).request_cache(nil).render[:request_cache]).to be_blank }
     specify { expect { subject.request_cache(true) }.not_to change { subject.render } }
   end
 
-  %i[search_type preference timeout].each do |name|
+  describe '#search_type' do
+    specify { expect(subject.search_type('foo').render).to include(search_type: 'foo') }
+    specify { expect(subject.search_type('foo').search_type('bar').render).to include(search_type: 'bar') }
+    specify { expect(subject.search_type('foo').search_type(nil).render[:search_type]).to be_blank }
+    specify { expect { subject.search_type('foo') }.not_to change { subject.render } }
+  end
+
+  %i[preference timeout].each do |name|
     describe "##{name}" do
       specify { expect(subject.send(name, :foo).render[:body]).to include(name => 'foo') }
       specify { expect(subject.send(name, :foo).send(name, :bar).render[:body]).to include(name => 'bar') }


### PR DESCRIPTION
Per ES docs: search_type, request_cache, and the allow_partial_search_results
should not be in the body. They should be sent as query string parameters. (https://www.elastic.co/guide/en/elasticsearch/reference/6.4/search-request-body.html#_parameters_4)

My understanding is that chewy should act like this:
``` 
  $ IssuesIndex.request_cache(true).render
  # good (new)
  $ {:index=>["issues"], :type=>["issue"], :body=>{}, :request_cache=>true}
  # bad (old)
  $ {:index=>["issues"], :type=>["issue"], :body=>{:request_cache=>true}
```

I believe this resolves #586 and part of #642.

This is my first PR to this repo so please let me know if you'd like any changes. The second commit (Adding AllowPartialSearchResults parameter) is definitely optional as it supports an ES 6 feature. What do you think?