### PR TITLE
CI: Drop unused sudo:false setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 services:
   - mongodb
 jdk:


### PR DESCRIPTION
Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-.infrastructure-migration