### PR TITLE
Insert request_strategy middleware before ActionDispatch::ShowExceptions

### DIFF
--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -68,7 +68,7 @@ module Chewy
     end
 
     initializer 'chewy.request_strategy' do |app|
-      app.config.middleware.insert_after(Rails::Rack::Logger, RequestStrategy)
+      app.config.middleware.insert_before(ActionDispatch::ShowExceptions, RequestStrategy)
     end
 
     initializer 'chewy.add_indices_path' do |_app|


### PR DESCRIPTION
Currently Chewy inserts request_strategy middleware after Rails::Rack::Logger. However people can use their custom loggers or use other gems, for instance https://github.com/rocketjob/rails_semantic_logger

Such gems swap `Rails::Rack::Logger` middleware with their implementations so on a moment when Chewy wants to insert its middleware after `Rails::Rack::Logger` it doesn't exist in the chain. 

In this PR instead of relying on `Rails::Rack::Logger` existence we place Chewy middleware before `ActionDispatch::ShowExceptions` that goes right after loggers. 

This also fixes this https://github.com/toptal/chewy/issues/286