### PR TITLE
Prepare release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # master
 
-# Version 5.0.1
+# Version 5.1.0
+
+## Breaking changes
+
+  * Add support for multiple indices in request (@pyromaniac, #657)
+
+  * Support `search_type`, `request_cache`, and `allow_partial_search_results` as query string parameters (@mattzollinhofer, #647)
 
 ## Changes
 
   * Speed up imports when `bulk_size` is specified (@yahooguntu, #606)
-
-  * Support `search_type`, `request_cache`, and `allow_partial_search_results` as query string parameters (@mattzollinhofer, #647)
-
-  * Support multiple indices in request (@pyromaniac, #657)
 
   * Insert `RequestStrategy` middleware before `ActionDispatch::ShowExceptions` (@dck, #682)
 

--- a/lib/chewy/version.rb
+++ b/lib/chewy/version.rb
@@ -1,3 +1,3 @@
 module Chewy
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.1.0'.freeze
 end


### PR DESCRIPTION
Turns out that we have breaking changes in release 5.0.1
We need to convert it to 5.1.0 release