### PR TITLE
Add multi search feature

### DIFF
--- a/lib/chewy/multi_search.rb
+++ b/lib/chewy/multi_search.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Chewy
+  # `Chewy::MultiSearch` provides an interface for executing multiple
+  # queries via the Elasticsearch Multi Search API. When a MultiSearch
+  # is performed it wraps the responses from Elasticsearch and assigns
+  # them to the appropriate queries.
+  class MultiSearch
+    attr_reader :queries
+
+    # Instantiate a new MultiSearch instance.
+    # 
+    # @param queries [Array<Chewy::Search::Request>]
+    # @option [Elasticsearch::Transport::Client] :client (Chewy.client)
+    #   The Elasticsearch client that should be used for issuing requests.
+    def initialize(queries, client: Chewy.client)
+      @client = client
+      @queries = Array(queries)
+    end
+
+    # Adds a query to be performed by the MultiSearch
+    # 
+    # @param query [Chewy::Search::Request]
+    def add_query(query)
+      @queries << query
+    end
+
+    # Performs any unperformed queries and returns the responses for all queries.
+    # 
+    # @return [Array<Chewy::Search::Response>]
+    def responses
+      perform
+      queries.map(&:response)
+    end
+
+    # Performs any unperformed queries.
+    def perform
+      unperformed_queries = queries.reject(&:performed?)
+      return if unperformed_queries.empty?
+
+      responses = msearch(unperformed_queries)["responses"]
+      unperformed_queries.zip(responses).map {|query, response| query.response = response }
+    end
+
+    private
+
+    attr_reader :client
+
+    def msearch(queries_to_search)
+      body = queries_to_search.flat_map {|query|
+        rendered = query.render
+        [rendered.except(:body), rendered[:body]]
+      }
+
+      client.msearch(body: body)
+    end
+  end
+
+  def self.msearch(queries)
+    Chewy::MultiSearch.new(queries)
+  end
+end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -112,7 +112,16 @@ module Chewy
       # @see Chewy::Search::Response
       # @return [Chewy::Search::Response] a response object instance
       def response
-        @response ||= Response.new(perform, loader, collection_paginator)
+        @response ||= build_response(perform)
+      end
+
+      # Wraps and sets the raw Elasticsearch response to provide access
+      # to convenience methods.
+      # 
+      # @see Chewy::Search::Response
+      # @param from_elasticsearch [Hash] An Elasticsearch response
+      def response=(from_elasticsearch)
+        @response = build_response(from_elasticsearch)
       end
 
       # ES request body
@@ -948,6 +957,13 @@ module Chewy
           end
       end
 
+      # Returns whether or not the query has been performed.
+      # 
+      # @return [true, false]
+      def performed?
+        !@response.nil?
+      end
+
     protected
 
       def initialize_clone(origin)
@@ -956,6 +972,10 @@ module Chewy
       end
 
     private
+
+      def build_response(raw_response)
+        Response.new(raw_response, loader, collection_paginator)
+      end
 
       def compare_internals(other)
         parameters == other.parameters
@@ -1031,10 +1051,6 @@ module Chewy
         else
           hit.fetch('_source', {})[field]
         end
-      end
-
-      def performed?
-        !@response.nil?
       end
 
       def collection_paginator

--- a/spec/chewy/journal_spec.rb
+++ b/spec/chewy/journal_spec.rb
@@ -54,7 +54,7 @@ describe Chewy::Journal do
             expect(Chewy::Stash::Journal.exists?).to eq true
 
             Timecop.freeze(update_time)
-            cities.first.update_attributes!(name: 'Supername')
+            cities.first.update!(name: 'Supername')
 
             Timecop.freeze(destroy_time)
             countries.last.destroy

--- a/spec/chewy/multi_search_spec.rb
+++ b/spec/chewy/multi_search_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'chewy/multi_search'
+
+describe Chewy::MultiSearch do
+  before { Chewy.massacre }
+
+  before do
+    stub_model(:city)
+    stub_model(:country)
+
+    stub_index(:places) do
+      define_type City do
+        field :name, KEYWORD_FIELD
+        field :country_id, KEYWORD_FIELD
+
+        def self.aggregate_by_country
+          aggs(country: { terms: { field: :country_id } })
+        end
+      end
+    end
+  end
+
+  let(:places_query) { PlacesIndex.all }
+
+  describe '#queries' do
+    specify 'returns the queries that are a part of the multi search' do
+      multi_search = described_class.new([places_query])
+      expect(multi_search.queries).to contain_exactly(places_query)
+    end
+  end
+
+  describe '#add_query' do
+    specify 'adds a query to the multi search' do
+      multi_search = described_class.new([])
+      expect {
+        multi_search.add_query(places_query)
+      }.to change {
+        multi_search.queries
+      }.from([]).to([places_query])
+    end
+  end
+
+  context 'when given two queries' do
+    let(:queries) { [aggregates, results] }
+    let(:aggregates) { PlacesIndex::City.aggregate_by_country.limit(0) }
+    let(:results) { PlacesIndex::City.limit(10) }
+    let(:multi_search) { described_class.new(queries) }
+    let(:cities) { Array.new(3) { |i| City.create! name: "Name#{i + 2}", country_id: i + 1 } }
+    before { PlacesIndex.import! city: cities }
+
+    describe '#perform' do
+      specify 'performs each query' do
+        expect { multi_search.perform }.
+          to change(aggregates, :performed?).from(false).to(true).
+          and change(results, :performed?).from(false).to(true)
+      end
+
+      specify 'issues a single request using the msearch endpoint', :aggregate_failures do
+        expect(Chewy.client).to receive(:msearch).once.and_return({'responses' => []})
+        expect(Chewy.client).to_not receive(:search)
+        multi_search.perform
+      end
+    end
+
+    describe '#responses' do
+      subject(:responses) { multi_search.responses }
+
+      context 'on a previously performed multi search' do
+        before { multi_search.perform }
+
+        it 'does not perform the query again' do
+          expect(Chewy.client).to_not receive(:msearch)
+          multi_search.responses
+        end
+      end
+
+      specify 'returns the results of each query', :aggregate_failures do
+        is_expected.to have(2).responses
+        expect(responses[0]).to be_a(Chewy::Search::Response)
+        expect(responses[1]).to be_a(Chewy::Search::Response)
+        expect(responses[1].wrappers).to all(be_a PlacesIndex::City)
+      end
+    end
+  end
+end

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -681,5 +681,38 @@ describe Chewy::Search::Request do
         )
       end
     end
+
+    describe '#response=' do
+      let(:query) { ProductsIndex.limit(0) }
+      let(:raw_response) { Chewy.client.search(query.render) }
+
+      it 'wraps and assigns the raw response' do
+        query.response = raw_response
+        expect(query.response).to be_a(Chewy::Search::Response)
+      end
+    end
+
+    describe '#performed?' do
+      let(:query) { ProductsIndex.limit(0) }
+      let(:raw_response) { Chewy.client.search(query.render) }
+
+      it 'is false on a new query' do
+        expect(query.performed?).to eq(false)
+      end
+
+      it 'is true after the search request was issued' do
+        expect {
+          # The `response` method has a side effect of performing unperformed
+          # queries.
+          query.response
+        }.to change(query, :performed?).from(false).to(true)
+      end
+
+      it 'is true after assigning a raw response' do
+        expect {
+          query.response = raw_response
+        }.to change(query, :performed?).from(false).to(true)
+      end
+    end
   end
 end

--- a/spec/chewy/type/import/bulk_builder_spec.rb
+++ b/spec/chewy/type/import/bulk_builder_spec.rb
@@ -117,7 +117,7 @@ describe Chewy::Type::Import::BulkBuilder do
       context 'updating parent' do
         before do
           PlacesIndex::City.import(city)
-          city.update_attributes(country_id: another_country.id)
+          city.update(country_id: another_country.id)
         end
         let(:index) { [city] }
 

--- a/spec/chewy/type/observe_spec.rb
+++ b/spec/chewy/type/observe_spec.rb
@@ -75,11 +75,11 @@ describe Chewy::Type::Observe do
       specify { expect { city.save! }.to update_index('cities#city').and_reindex(city).only }
       specify { expect { city.save! }.to update_index('countries#country').and_reindex(country1).only }
 
-      specify { expect { city.update_attributes!(country: nil) }.to update_index('cities#city').and_reindex(city).only }
-      specify { expect { city.update_attributes!(country: nil) }.to update_index('countries#country').and_reindex(country1).only }
+      specify { expect { city.update!(country: nil) }.to update_index('cities#city').and_reindex(city).only }
+      specify { expect { city.update!(country: nil) }.to update_index('countries#country').and_reindex(country1).only }
 
-      specify { expect { city.update_attributes!(country: country2) }.to update_index('cities#city').and_reindex(city).only }
-      specify { expect { city.update_attributes!(country: country2) }.to update_index('countries#country').and_reindex(country1, country2).only }
+      specify { expect { city.update!(country: country2) }.to update_index('cities#city').and_reindex(city).only }
+      specify { expect { city.update!(country: country2) }.to update_index('countries#country').and_reindex(country1, country2).only }
     end
 
     context do


### PR DESCRIPTION
The Elasticsearch [Multi Search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) can be used to issue multiple search queries at a time.