### PR TITLE
Correctly report indices and aliases

### DIFF
--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -172,7 +172,7 @@ module Chewy
         def reset!(suffix = nil, apply_journal: true, journal: false, **import_options)
           result = if suffix.present?
             start_time = Time.now
-            indexes = self.indexes
+            indexes = self.indexes - [index_name]
             create! suffix, alias: false
 
             general_name = index_name

--- a/lib/chewy/index/aliases.rb
+++ b/lib/chewy/index/aliases.rb
@@ -5,14 +5,13 @@ module Chewy
 
       module ClassMethods
         def indexes
-          client.indices.get_alias(name: index_name).keys
+          client.indices.get(index: "#{index_name}*").keys
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
           []
         end
 
         def aliases
-          name = index_name
-          client.indices.get_alias(index: name, name: '*')[name].try(:[], 'aliases').try(:keys) || []
+          client.indices.get(index: "#{index_name}*").values.flat_map {|i| i['aliases'].keys }
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
           []
         end

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -28,7 +28,7 @@ describe Chewy::Index::Actions do
       before { DummiesIndex.create '2013' }
       specify { expect(Chewy.client.indices.exists(index: 'dummies')).to eq(true) }
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
-      specify { expect(DummiesIndex.aliases).to eq([]) }
+      specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
       specify { expect(DummiesIndex.create('2013')).to eq(false) }
       specify { expect(DummiesIndex.create('2014')['acknowledged']).to eq(true) }
@@ -44,7 +44,7 @@ describe Chewy::Index::Actions do
       specify { expect(Chewy.client.indices.exists(index: 'dummies')).to eq(false) }
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
       specify { expect(DummiesIndex.aliases).to eq([]) }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
     end
   end
 
@@ -64,7 +64,7 @@ describe Chewy::Index::Actions do
       before { DummiesIndex.create! '2013' }
       specify { expect(Chewy.client.indices.exists(index: 'dummies')).to eq(true) }
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
-      specify { expect(DummiesIndex.aliases).to eq([]) }
+      specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
       specify do
         expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/index_already_exists_exception.*dummies_2013/)
@@ -82,7 +82,7 @@ describe Chewy::Index::Actions do
       specify { expect(Chewy.client.indices.exists(index: 'dummies')).to eq(false) }
       specify { expect(Chewy.client.indices.exists(index: 'dummies_2013')).to eq(true) }
       specify { expect(DummiesIndex.aliases).to eq([]) }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
     end
   end
 
@@ -184,19 +184,19 @@ describe Chewy::Index::Actions do
       before { DummiesIndex.purge }
       specify { expect(DummiesIndex).to be_exists }
       specify { expect(DummiesIndex.aliases).to eq([]) }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
 
       context do
         before { DummiesIndex.purge }
         specify { expect(DummiesIndex).to be_exists }
         specify { expect(DummiesIndex.aliases).to eq([]) }
-        specify { expect(DummiesIndex.indexes).to eq([]) }
+        specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
       end
 
       context do
         before { DummiesIndex.purge('2013') }
         specify { expect(DummiesIndex).to be_exists }
-        specify { expect(DummiesIndex.aliases).to eq([]) }
+        specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
         specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
       end
     end
@@ -204,20 +204,20 @@ describe Chewy::Index::Actions do
     context do
       before { DummiesIndex.purge('2013') }
       specify { expect(DummiesIndex).to be_exists }
-      specify { expect(DummiesIndex.aliases).to eq([]) }
+      specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
 
       context do
         before { DummiesIndex.purge }
         specify { expect(DummiesIndex).to be_exists }
         specify { expect(DummiesIndex.aliases).to eq([]) }
-        specify { expect(DummiesIndex.indexes).to eq([]) }
+        specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
       end
 
       context do
         before { DummiesIndex.purge('2014') }
         specify { expect(DummiesIndex).to be_exists }
-        specify { expect(DummiesIndex.aliases).to eq([]) }
+        specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
         specify { expect(DummiesIndex.indexes).to eq(['dummies_2014']) }
       end
     end
@@ -231,19 +231,19 @@ describe Chewy::Index::Actions do
       before { DummiesIndex.purge! }
       specify { expect(DummiesIndex).to be_exists }
       specify { expect(DummiesIndex.aliases).to eq([]) }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
 
       context do
         before { DummiesIndex.purge! }
         specify { expect(DummiesIndex).to be_exists }
         specify { expect(DummiesIndex.aliases).to eq([]) }
-        specify { expect(DummiesIndex.indexes).to eq([]) }
+        specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
       end
 
       context do
         before { DummiesIndex.purge!('2013') }
         specify { expect(DummiesIndex).to be_exists }
-        specify { expect(DummiesIndex.aliases).to eq([]) }
+        specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
         specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
       end
     end
@@ -251,20 +251,20 @@ describe Chewy::Index::Actions do
     context do
       before { DummiesIndex.purge!('2013') }
       specify { expect(DummiesIndex).to be_exists }
-      specify { expect(DummiesIndex.aliases).to eq([]) }
+      specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
 
       context do
         before { DummiesIndex.purge! }
         specify { expect(DummiesIndex).to be_exists }
         specify { expect(DummiesIndex.aliases).to eq([]) }
-        specify { expect(DummiesIndex.indexes).to eq([]) }
+        specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
       end
 
       context do
         before { DummiesIndex.purge!('2014') }
         specify { expect(DummiesIndex).to be_exists }
-        specify { expect(DummiesIndex.aliases).to eq([]) }
+        specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
         specify { expect(DummiesIndex.indexes).to eq(['dummies_2014']) }
       end
     end
@@ -337,13 +337,13 @@ describe Chewy::Index::Actions do
 
         specify { expect(CitiesIndex.all).to have(1).item }
         specify { expect(CitiesIndex.aliases).to eq([]) }
-        specify { expect(CitiesIndex.indexes).to eq([]) }
+        specify { expect(CitiesIndex.indexes).to eq(['cities']) }
 
         context do
           before { CitiesIndex.reset!('2013') }
 
           specify { expect(CitiesIndex.all).to have(1).item }
-          specify { expect(CitiesIndex.aliases).to eq([]) }
+          specify { expect(CitiesIndex.aliases).to eq(['cities']) }
           specify { expect(CitiesIndex.indexes).to eq(['cities_2013']) }
         end
 
@@ -352,7 +352,7 @@ describe Chewy::Index::Actions do
 
           specify { expect(CitiesIndex.all).to have(1).item }
           specify { expect(CitiesIndex.aliases).to eq([]) }
-          specify { expect(CitiesIndex.indexes).to eq([]) }
+          specify { expect(CitiesIndex.indexes).to eq(['cities']) }
         end
       end
 
@@ -360,14 +360,14 @@ describe Chewy::Index::Actions do
         before { CitiesIndex.reset!('2013') }
 
         specify { expect(CitiesIndex.all).to have(1).item }
-        specify { expect(CitiesIndex.aliases).to eq([]) }
+        specify { expect(CitiesIndex.aliases).to eq(['cities']) }
         specify { expect(CitiesIndex.indexes).to eq(['cities_2013']) }
 
         context do
           before { CitiesIndex.reset!('2014') }
 
           specify { expect(CitiesIndex.all).to have(1).item }
-          specify { expect(CitiesIndex.aliases).to eq([]) }
+          specify { expect(CitiesIndex.aliases).to eq(['cities']) }
           specify { expect(CitiesIndex.indexes).to eq(['cities_2014']) }
           specify { expect(Chewy.client.indices.exists(index: 'cities_2013')).to eq(false) }
         end
@@ -377,7 +377,7 @@ describe Chewy::Index::Actions do
 
           specify { expect(CitiesIndex.all).to have(1).item }
           specify { expect(CitiesIndex.aliases).to eq([]) }
-          specify { expect(CitiesIndex.indexes).to eq([]) }
+          specify { expect(CitiesIndex.indexes).to eq(['cities']) }
           specify { expect(Chewy.client.indices.exists(index: 'cities_2013')).to eq(false) }
         end
       end

--- a/spec/chewy/index/aliases_spec.rb
+++ b/spec/chewy/index/aliases_spec.rb
@@ -10,13 +10,13 @@ describe Chewy::Index::Aliases do
 
     context do
       before { DummiesIndex.create! }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
     end
 
     context do
       before { DummiesIndex.create! }
       before { Chewy.client.indices.put_alias index: 'dummies', name: 'dummies_2013' }
-      specify { expect(DummiesIndex.indexes).to eq([]) }
+      specify { expect(DummiesIndex.indexes).to eq(['dummies']) }
     end
 
     context do
@@ -43,7 +43,7 @@ describe Chewy::Index::Aliases do
 
     context do
       before { DummiesIndex.create! '2013' }
-      specify { expect(DummiesIndex.aliases).to eq([]) }
+      specify { expect(DummiesIndex.aliases).to eq(['dummies']) }
     end
   end
 end


### PR DESCRIPTION
Improve the reporting on indices and aliases that match index naming.

### Before
Indices created via Chewy without a suffix would fail to report themselves as an index or alias for the Chewy index.
```ruby
DummyIndex.create! # => {'acknowledged' => true}
DummyIndex.indexes # => []
DummyIndex.aliases # => []
```

Indices created via Chewy with a suffix would correctly report the suffixed index but would fail to report the alias
```ruby
DummyIndex.create!('2013') # => {'acknowledged' => true}
DummyIndex.indexes # => ['dummies_2013']
DummyIndex.aliases # => []
```

### After
Indices created via Chewy without a suffix will correctly report themselves as an index.
```ruby
DummyIndex.create!
DummyIndex.indexes # => ['dummies']
DummyIndex.aliases # => []
```

Indices created via Chewy with a suffix will correctly report the alias
```ruby
DummyIndex.create!('2013') # => {'acknowledged' => true}
DummyIndex.indexes # => ['dummies_2013']
DummyIndex.aliases # => ['dummies']
```