### PR TITLE
Clear the scroll by id after completing scroll_batches

### DIFF
--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -103,6 +103,11 @@ describe Chewy::Search::Scrolling, :orm do
         end
       end
 
+      it 'clears the scroll after completion' do
+        expect(Chewy.client).to receive(:clear_scroll).with(scroll_id: anything).once.and_call_original
+        request.scroll_batches(batch_size: 3) {}
+      end
+
       context 'instrumentation' do
         specify do
           outer_payload = []


### PR DESCRIPTION
ElasticSearch has settings that limit the number of concurrent scrolls on the cluster. Scrolls are cleared automatically after the scroll ttl (eg, "1m") but I've found that iterating a lot of data in a lot of parallel jobs makes it easy to hit this limit. This may be avoided by staggering parallelism differently or by setting shorter scroll ttls, but it seems to also make sense to clear out the old scrolls when the use of scroll_batches is complete. 