### PR TITLE
Avoid importing everything when given an empty relation

### DIFF
--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -136,6 +136,8 @@ module Chewy
         %i[import import!].each do |method|
           class_eval <<-METHOD, __FILE__, __LINE__ + 1
             def #{method}(*args)
+              return if args.first.blank? && !args.first.nil?
+
               options = args.extract_options!
               if args.one? && type_names.one?
                 objects = {type_names.first.to_sym => args.first}

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -281,6 +281,12 @@ describe Chewy::Index::Actions do
 
     specify { expect(CitiesIndex.import).to eq(true) }
 
+    specify 'with an empty array' do
+      expect(CitiesIndex).not_to receive(:exists?)
+      expect(CitiesIndex).not_to receive(:create!)
+      CitiesIndex.import([])
+    end
+
     context do
       before do
         stub_index(:cities) do
@@ -304,6 +310,12 @@ describe Chewy::Index::Actions do
     let!(:dummy_cities) { Array.new(3) { |i| City.create(id: i + 1, name: "name#{i}") } }
 
     specify { expect(CitiesIndex.import!).to eq(true) }
+
+    specify 'with an empty array' do
+      expect(CitiesIndex).not_to receive(:exists?)
+      expect(CitiesIndex).not_to receive(:create!)
+      CitiesIndex.import!([])
+    end
 
     context do
       before do


### PR DESCRIPTION
Users can currently call `import` and `import!` directly on an index. If
these methods are called without arguments, the index imports all data
matching the type definition.
If these methods are called with an argument, ex.
`UsersIndex.import(User.where('rating > 100'))`, only the given scope or
array will be imported into the index.
If these methods are called with an argument, but that argument is empty
(for example `User.where('rating > 100')` returns an empty relation),
the methods were behaving as if they had no args (importing all the data
for an index).
This is undesired behavior, as the expectation should be for an import
with an argument that is empty to import nothing.
The changes proposed here mirror the changes created in this
[commit](https://github.com/toptal/chewy/commit/2eeff144925d92e6410a4aa2efbed3e0aef24b48), so that the behavior of doing `UsersIndex.import([])` is the same as doing `UsersIndex::User.import([])`.