### PR TITLE
Allow configuration of Active Job queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,11 @@ Chewy.strategy(:sidekiq) do
 end
 ```
 
+The default queue name is `chewy`, you can customize it in settings: `sidekiq.queue_name`
+```
+Chewy.settings[:sidekiq] = {queue: :low}
+```
+
 #### `:active_job`
 
 This does the same thing as `:atomic`, but using ActiveJob. This will inherit the ActiveJob configuration settings including the `active_job.queue_adapter` setting for the environment. Patch `Chewy::Strategy::ActiveJob::Worker` for index updates improving.
@@ -686,6 +691,11 @@ This does the same thing as `:atomic`, but using ActiveJob. This will inherit th
 Chewy.strategy(:active_job) do
   City.popular.map(&:do_some_update_action!)
 end
+```
+
+The default queue name is `chewy`, you can customize it in settings: `active_job.queue_name`
+```
+Chewy.settings[:active_job] = {queue: :low}
 ```
 
 #### `:shoryuken`

--- a/lib/chewy/strategy/active_job.rb
+++ b/lib/chewy/strategy/active_job.rb
@@ -11,7 +11,7 @@ module Chewy
     #
     class ActiveJob < Atomic
       class Worker < ::ActiveJob::Base
-        queue_as :chewy
+        queue_as { Chewy.settings.dig(:active_job, :queue) || 'chewy' }
 
         def perform(type, ids, options = {})
           options[:refresh] = !Chewy.disable_refresh_async if Chewy.disable_refresh_async

--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -33,7 +33,7 @@ module Chewy
     private
 
       def sidekiq_queue
-        Chewy.settings.fetch(:sidekiq, {})[:queue] || 'chewy'
+        Chewy.settings.dig(:sidekiq, :queue) || 'chewy'
       end
     end
   end


### PR DESCRIPTION
We can configure sidekiq queue in settings, but ActiveJob queue name was hadcoded. This PR changes this and allows configuring AJ queue by setting ` Chewy.settings[:active_job][:queue]`.