### PR TITLE
Fix deprecation warning for contructing new BigDecimal

### DIFF
--- a/lib/chewy/backports/duplicable.rb
+++ b/lib/chewy/backports/duplicable.rb
@@ -79,7 +79,7 @@ end
 require 'bigdecimal'
 class BigDecimal
   begin
-    BigDecimal.new('4.56').dup
+    BigDecimal('4.56').dup
 
     def duplicable?
       true


### PR DESCRIPTION
This fixes the warning:

```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

