### PR TITLE
Update instructions for AWS ElasticSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,22 @@ See [config.rb](lib/chewy/config.rb) for more details.
 
 #### Aws Elastic Search
 If you would like to use AWS's ElasticSearch using an IAM user policy, you will need to sign your requests for the `es:*` action by injecting the appropriate headers passing a proc to `transport_options`.
+You'll need an additional gem for Faraday middleware: add `gem 'faraday_middleware-aws-sigv4'` to your Gemfile.
 
 ```ruby
- Chewy.settings = {
+  require 'faraday_middleware/aws_sigv4'
+
+  Chewy.settings = {
     host: 'http://my-es-instance-on-aws.us-east-1.es.amazonaws.com:80',
+    port: 80, # 443 for https host
     transport_options: {
       headers: { content_type: 'application/json' },
       proc: -> (f) do
-          f.request :aws_signers_v4,
-                    service_name: 'es',
+          f.request :aws_sigv4,
+                    service: 'es',
                     region: 'us-east-1',
-                    credentials: Aws::Credentials.new(
-                      ENV['AWS_ACCESS_KEY'],
-                      ENV['AWS_SECRET_ACCESS_KEY'])
+                    access_key_id: ENV['AWS_ACCESS_KEY'],
+                    secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
       end
     }
   }


### PR DESCRIPTION
Fix instructions for AWS ElasticSearch configuration in README as it is outdated.