### PR TITLE
Symbolize sidekiq options

### DIFF
--- a/lib/chewy/strategy/sidekiq.rb
+++ b/lib/chewy/strategy/sidekiq.rb
@@ -15,7 +15,7 @@ module Chewy
 
         def perform(type, ids, options = {})
           options[:refresh] = !Chewy.disable_refresh_async if Chewy.disable_refresh_async
-          type.constantize.import!(ids, options)
+          type.constantize.import!(ids, options.symbolize_keys)
         end
       end
 


### PR DESCRIPTION
Sidekiq will convert symbols to strings when serializing arguments.
(See https://github.com/mperham/sidekiq/issues/3893 and https://github.com/mperham/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple)

However, classes such as Routine use keyword arguments as initializers and will throw an argument error if provided options with string keys. (See https://github.com/toptal/chewy/blob/v5.0.0/lib/chewy/type/import/routine.rb#L44)

For example:
```ruby
# With symbol options
CitiesIndex::City.import!([1], update_fields: [:name])
=> true

# With string options
CitiesIndex::City.import!([1], "update_fields" => [:name]) 
ArgumentError: wrong number of arguments (given 2, expected 1)
```

A simple solution is to symbolize the options before running `import!`