### PR TITLE
Fix more ruby 2.7 keyword params deprecation warnings

### DIFF
--- a/lib/chewy/query/loading.rb
+++ b/lib/chewy/query/loading.rb
@@ -94,7 +94,7 @@ module Chewy
         loaded_objects = Hash[_results.group_by(&:class).map do |type, objects|
           next if except.include?(type.type_name)
           next if only.present? && !only.include?(type.type_name)
-          loaded = type.adapter.load(objects.map(&:id), options.merge(_type: type)) || objects
+          loaded = type.adapter.load(objects.map(&:id), **options.merge(_type: type)) || objects
           [type, loaded.index_by.with_index do |loaded_object, i|
             objects[i]._object = loaded_object
             objects[i]

--- a/lib/chewy/search/loader.rb
+++ b/lib/chewy/search/loader.rb
@@ -52,7 +52,7 @@ module Chewy
 
           type = derive_type(index_name, type_name)
           ids = hit_group.map { |hit| hit['_id'] }
-          loaded = type.adapter.load(ids, @options.merge(_type: type))
+          loaded = type.adapter.load(ids, **@options.merge(_type: type))
           loaded ||= hit_group.map { |hit| type.build(hit) }
 
           result.merge!(hit_group.zip(loaded).to_h)

--- a/lib/chewy/type/adapter/active_record.rb
+++ b/lib/chewy/type/adapter/active_record.rb
@@ -22,7 +22,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).inject(true) do |result, ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).inject(true) do |result, ids|
             objects = if options[:raw_import]
               raw_default_scope_where_ids_in(ids, options[:raw_import])
             else

--- a/lib/chewy/type/adapter/mongoid.rb
+++ b/lib/chewy/type/adapter/mongoid.rb
@@ -25,7 +25,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).map do |ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).map do |ids|
             yield grouped_objects(default_scope_where_ids_in(ids))
           end.all?
         end

--- a/lib/chewy/type/adapter/orm.rb
+++ b/lib/chewy/type/adapter/orm.rb
@@ -89,7 +89,7 @@ module Chewy
 
           if options[:fields].present? || collection.is_a?(relation_class)
             collection = all_scope_where_ids_in(identify(collection)) unless collection.is_a?(relation_class)
-            pluck_in_batches(collection, options.slice(:fields, :batch_size, :typecast), &block)
+            pluck_in_batches(collection, **options.slice(:fields, :batch_size, :typecast), &block)
           else
             identify(collection).each_slice(options[:batch_size]) do |batch|
               yield batch

--- a/lib/chewy/type/adapter/sequel.rb
+++ b/lib/chewy/type/adapter/sequel.rb
@@ -22,7 +22,7 @@ module Chewy
         end
 
         def import_scope(scope, options)
-          pluck_in_batches(scope, options.slice(:batch_size)).inject(true) do |result, ids|
+          pluck_in_batches(scope, **options.slice(:batch_size)).inject(true) do |result, ids|
             result & yield(grouped_objects(default_scope_where_ids_in(ids).all))
           end
         end

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -10,7 +10,7 @@ module Chewy
 
       IMPORT_WORKER = lambda do |type, options, total, ids, index|
         ::Process.setproctitle("chewy [#{type}]: import data (#{index + 1}/#{total})")
-        routine = Routine.new(type, options)
+        routine = Routine.new(type, **options)
         type.adapter.import(*ids, routine.options) do |action_objects|
           routine.process(**action_objects)
         end
@@ -19,7 +19,7 @@ module Chewy
 
       LEFTOVERS_WORKER = lambda do |type, options, total, body, index|
         ::Process.setproctitle("chewy [#{type}]: import leftovers (#{index + 1}/#{total})")
-        routine = Routine.new(type, options)
+        routine = Routine.new(type, **options)
         routine.perform_bulk(body)
         routine.errors
       end
@@ -127,7 +127,7 @@ module Chewy
 
         def import_routine(*args)
           return if args.first.blank? && !args.first.nil?
-          routine = Routine.new(self, args.extract_options!)
+          routine = Routine.new(self, **args.extract_options!)
           routine.create_indexes!
 
           if routine.parallel_options

--- a/lib/chewy/type/import/routine.rb
+++ b/lib/chewy/type/import/routine.rb
@@ -66,7 +66,7 @@ module Chewy
         def create_indexes!
           Chewy::Stash::Journal.create if @options[:journal]
           return if Chewy.configuration[:skip_index_creation_on_import]
-          @type.index.create!(@bulk_options.slice(:suffix)) unless @type.index.exists?
+          @type.index.create!(**@bulk_options.slice(:suffix)) unless @type.index.exists?
         end
 
         # The main process method. Converts passed objects to thr bulk request body,


### PR DESCRIPTION
Fixes deprecation warnings
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```


1. Fixed warning when calling `response.records`, warning backtrace:
```
     # gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/search/loader.rb:55:in `block in load'
     # gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/search/loader.rb:50:in `each'
     # gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/search/loader.rb:50:in `each_with_object'
     # gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/search/loader.rb:50:in `load'
     # gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/search/response.rb:85:in `objects'
```

2. Fixed warning when calling `SomeIndex.reset!((Time.now.to_f * 1000).round)`, warning backtrace:
```
     # gems/chewy-74470f2525b2/lib/chewy/type/adapter/active_record.rb:25:in `import_scope'
     # gems/chewy-74470f2525b2/lib/chewy/type/adapter/orm.rb:79:in `import'
     # gems/chewy-74470f2525b2/lib/chewy/type/import.rb:142:in `block in import_linear'
     # /home/aglushkov/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
     # /home/aglushkov/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
     # /home/aglushkov/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
     # gems/chewy-74470f2525b2/lib/chewy/type/import.rb:141:in `import_linear'
     # gems/chewy-74470f2525b2/lib/chewy/type/import.rb:136:in `import_routine'
     # gems/chewy-74470f2525b2/lib/chewy/type/import.rb:76:in `import'
     # gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:149:in `block in import'
     # gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:147:in `map'
     # gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:147:in `import'
     # gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:182:in `reset!'
```

3. Same  `SomeIndex.reset!((Time.now.to_f * 1000).round)`, warning backtrace:
```
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/type/import.rb:130:in `new'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/type/import.rb:130:in `import_routine'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/type/import.rb:76:in `import'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:149:in `block in import'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:147:in `map'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:147:in `import'
# gems/2.7.0/bundler/gems/chewy-74470f2525b2/lib/chewy/index/actions.rb:182:in `reset!'
```
