### PR TITLE
Patch ElasticSearch deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 
-  * Update gemspec dependencies for Rails. Update CI gemfiles and matrix to tests against current LTS Rails versions.
+  * Update gemspec dependencies for Rails. Update CI gemfiles and matrix to tests against current LTS Rails versions. (@bhacaz, #733)
+
+  * Correct deprecation warning for Elasticsearch 5.6 to 6: empty query for`_delete_by_query`, delete by alias, `index_already_exists_exception` renaming (@bhacaz, #735)
 
 # Version 5.1.0
 

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -74,7 +74,13 @@ module Chewy
         #   UsersIndex.delete '01-2014' # deletes `users_01-2014` index
         #
         def delete(suffix = nil)
-          result = client.indices.delete index: index_name(suffix: suffix)
+          # Verify that the index_name is really the index_name and not an alias.
+          #
+          #   "The index parameter in the delete index API no longer accepts alias names.
+          #   Instead, it accepts only index names (or wildcards which will expand to matching indices)."
+          #   https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_delete_index_api_resolves_indices_expressions_only_against_indices
+          index_names = client.indices.get_alias(index: index_name(suffix: suffix)).keys
+          result = client.indices.delete index: index_names.join(',')
           Chewy.wait_for_status if result
           result
           # es-ruby >= 1.0.10 handles Elasticsearch::Transport::Transport::Errors::NotFound

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -943,6 +943,7 @@ module Chewy
             if Runtime.version < '5.0'
               delete_by_query_plugin(request_body)
             else
+              request_body[:body] = {query: {match_all: {}}} if request_body[:body].empty?
               Chewy.client.delete_by_query(request_body)
             end
           end

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -55,7 +55,7 @@ describe Chewy::Index::Actions do
     context do
       before { DummiesIndex.create }
       specify do
-        expect { DummiesIndex.create! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/index_already_exists_exception.*dummies/)
+        expect { DummiesIndex.create! }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/already exists.*dummies/)
       end
       specify { expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/Invalid alias name \[dummies\]/) }
     end
@@ -67,7 +67,7 @@ describe Chewy::Index::Actions do
       specify { expect(DummiesIndex.aliases).to eq([]) }
       specify { expect(DummiesIndex.indexes).to eq(['dummies_2013']) }
       specify do
-        expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/index_already_exists_exception.*dummies_2013/)
+        expect { DummiesIndex.create!('2013') }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest).with_message(/already exists.*dummies_2013/)
       end
       specify { expect(DummiesIndex.create!('2014')['acknowledged']).to eq(true) }
 

--- a/spec/chewy/type/adapter/active_record_spec.rb
+++ b/spec/chewy/type/adapter/active_record_spec.rb
@@ -454,9 +454,9 @@ describe Chewy::Type::Adapter::ActiveRecord, :active_record do
       specify do
         expect(subject.import_fields(fields: [:updated_at], typecast: false))
           .to match([contain_exactly(
-            [1, match(/#{Time.now.strftime('%Y-%m-%d')}/)],
-            [2, match(/#{Time.now.strftime('%Y-%m-%d')}/)],
-            [3, match(/#{Time.now.strftime('%Y-%m-%d')}/)]
+            [1, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)],
+            [2, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)],
+            [3, match(/#{Time.now.utc.strftime('%Y-%m-%d')}/)]
           )])
       end
     end


### PR DESCRIPTION
Hi, since some peoples seems to work/wish to make Chewy compatible with ElasticSearch 6-7, here is a small PR to fix the deprecation warning from ElasticSearch. It seems to be a good first step.