### PR TITLE
Fix nil children when using witchcraft

### DIFF
--- a/lib/chewy/type/witchcraft.rb
+++ b/lib/chewy/type/witchcraft.rb
@@ -79,7 +79,9 @@ module Chewy
           if field.children.present? && !field.multi_field?
             <<-RUBY
               (result#{nesting} = #{fetcher}
-              if result#{nesting}.respond_to?(:to_ary)
+              if result#{nesting}.nil?
+                nil
+              elsif result#{nesting}.respond_to?(:to_ary)
                 result#{nesting}.map do |object#{nesting}|
                   #{composed_values(field, nesting)}
                 end

--- a/spec/chewy/type/witchcraft_spec.rb
+++ b/spec/chewy/type/witchcraft_spec.rb
@@ -181,6 +181,21 @@ describe Chewy::Type::Witchcraft do
           ]}.as_json)
         end
       end
+
+      context do
+        mapping do
+          field :not_present do
+            field :nothing
+          end
+        end
+
+        let(:object) do
+          double(not_present: nil)
+        end
+        specify do
+          expect(type.cauldron.brew(object)).to eq({not_present: nil}.as_json)
+        end
+      end
     end
 
     context 'dynamic fields' do


### PR DESCRIPTION
The functionality of Chewy without witchcraft enabled simply nulls out any children fields where the child is null. With witchcraft enabled, Chewy will try to traverse objects even when a child is null. Code change addresses this issue.