### PR TITLE
Prevent calling Index#delete with an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+  * [#740](https://github.com/toptal/chewy/pull/740): Prevent calling Index#delete when the index does not exist. ([@bhacaz][])
   * [#736](https://github.com/toptal/chewy/pull/736): Fix nil children when using witchcraft ([@taylor-au][])
 
 ## Changes

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -74,6 +74,8 @@ module Chewy
         #   UsersIndex.delete '01-2014' # deletes `users_01-2014` index
         #
         def delete(suffix = nil)
+          return false unless exists?
+
           # Verify that the index_name is really the index_name and not an alias.
           #
           #   "The index parameter in the delete index API no longer accepts alias names.


### PR DESCRIPTION
Bug introduced with #735

ES client return an `Elasticsearch::Transport::Transport::Errors::BadRequest` error, which is not rescued. To keep the same behaviour, I simply call the ES client with the `index_name`. 