### PR TITLE
Document string vs keyword/text for ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or install it yourself as:
 
 ### Ruby
 
-Chewy is compatible with MRI 2.5-3.0¹. 
+Chewy is compatible with MRI 2.5-3.0¹.
 
 > ¹ Ruby 3 is only supported with Rails 6.1
 
@@ -197,7 +197,7 @@ Chewy.settings = {
       field :badges, value: ->(user) { user.badges.map(&:name) } # passing array values to index
       field :projects do # the same block syntax for multi_field, if `:type` is specified
         field :title
-        field :description # default data type is `string`
+        field :description # default data type is `text`
         # additional top-level objects passed to value proc:
         field :categories, value: ->(project, user) { project.categories.map(&:name) if user.active? }
       end

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -46,7 +46,7 @@ module Chewy
       # Default options for root of Chewy type. Allows to set default options
       # for type mappings like `_all`.
       :default_root_options,
-      # Default field type for any field in any Chewy type. Defaults to 'string'.
+      # Default field type for any field in any Chewy type. Defaults to 'text'.
       :default_field_type
 
     attr_reader :transport_logger, :transport_tracer,

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -1,0 +1,8 @@
+# Chewy 5 to 6
+
+It's a documentation stub, it'll be developed during the process of preparing chewy for ES6 compatibility.
+
+When you want to prepare your application for chewy6:
+
+* replace field with `{ type: 'string', index: 'not_analyzed'}` by `{type: 'keyword'}`
+* replace field with `{ type: 'string', index: 'analyzed'}` by `{type: 'text'}`


### PR DESCRIPTION
The only usage of `string` that I found in chewy was hidden in `Chewy::Runtime.version < '5.0'`. I've updated comments and started a file with migration guide.