### PR TITLE
Update ES query in Chewy::Stash::Journal.for to support ES < 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+  * [#742](https://github.com/toptal/chewy/pull/742): Update Chewy::Stash::Journal.for query to also support ES < 2 ([@bhacaz][])
   * [#736](https://github.com/toptal/chewy/pull/736): Fix nil children when using witchcraft ([@taylor-au][])
 
 ## Changes


### PR DESCRIPTION
Hi, I know that change can seems no necessary, but the gem did a really good job supporting old version of ElasticSearch. However I found that query while testing an old app and it takes for granted that the `search_class` is `Chewy::Search::Request` and it doesn't work with the old `Chewy::Query`.

Here the error I got before the change:

```
NoMethodError: undefined method `or' for #<Chewy::Stash::Journal::Query:0x00007fc105a7ee78>
```

I thing the new implementation looks a bit heavy and doesn’t use must of the DSLs, but it works for ES < 2 and newer.

---

Step to reproduce:

```ruby
require 'chewy'
Chewy.search_class = Chewy::Query
class D; end
class DummiesIndex < Chewy::Index
  define_type D do
  end
end
Chewy::Stash::Journal.for(DummiesIndex)
```

Error:

```
Traceback (most recent call last):
        7: from /Users/bhacaz/.rbenv/versions/2.6.6/bin/irb:23:in `<main>'
        6: from /Users/bhacaz/.rbenv/versions/2.6.6/bin/irb:23:in `load'
        5: from /Users/bhacaz/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        4: from (irb):29
        3: from /Users/bhacaz/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/chewy-5.2.0/lib/chewy/stash.rb:49:in `for'
        2: from /Users/bhacaz/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/chewy-5.2.0/lib/chewy/stash.rb:49:in `each'
        1: from /Users/bhacaz/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/chewy-5.2.0/lib/chewy/stash.rb:50:in `block in for'
NoMethodError (undefined method `or' for #<Chewy::Stash::Journal::Query:0x00007fc8a82b1808>)
```