### PR TITLE
Remove not analyzed

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ To define a multi field you have to specify any type except for `object` or `nes
 ```ruby
 field :full_name, type: 'text', value: ->{ full_name.strip } do
   field :ordered, analyzer: 'ordered'
-  field :untouched, index: 'not_analyzed'
+  field :untouched, type: 'keyword'
 end
 ```
 

--- a/lib/chewy/fields/base.rb
+++ b/lib/chewy/fields/base.rb
@@ -34,12 +34,6 @@ module Chewy
         mapping.reverse_merge!(options)
         mapping.reverse_merge!(type: (children.present? ? 'object' : Chewy.default_field_type))
 
-        # This is done to support ES2 journaling and will be removed soon
-        if mapping[:type] == 'keyword' && Chewy::Runtime.version < '5.0'
-          mapping[:type] = 'string'
-          mapping[:index] = 'not_analyzed'
-        end
-
         {name => mapping}
       end
 

--- a/spec/chewy/search_spec.rb
+++ b/spec/chewy/search_spec.rb
@@ -71,12 +71,12 @@ describe Chewy::Search do
             filter { match name: "Name#{index}" }
           end
 
-          field :name, **KEYWORD_FIELD
+          field :name, type: 'keyword'
           field :rating, type: :integer
         end
 
         define_type Country do
-          field :name, **KEYWORD_FIELD
+          field :name, type: 'keyword'
           field :rating, type: :integer
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,14 +33,7 @@ Chewy.settings = {
   }
 }
 
-Chewy.default_field_type = 'string' if Chewy::Runtime.version < '5.0'
 # Chewy.transport_logger = Logger.new(STDERR)
-
-KEYWORD_FIELD = if Chewy::Runtime.version < '5.0'
-  {type: 'string', index: 'not_analyzed'}
-else
-  {type: 'keyword'}
-end
 
 RSpec.configure do |config|
   config.mock_with :rspec


### PR DESCRIPTION
not_analyzed and string types are deprecated in the es5.

Also, I've removed the default value `srting` for old versions of the elastic search.

No new failing specs were introduced.