### PR TITLE
Avoid importing everything when given an empty relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+  * [#749](https://github.com/toptal/chewy/pull/749): Avoid importing everything when given an empty relation ([@JF-Lalonde][][@dalthon][])
   * [#736](https://github.com/toptal/chewy/pull/736): Fix nil children when using witchcraft ([@taylor-au][])
 
 ## Changes
@@ -494,6 +495,8 @@
   * Initial version
 
 
+[@JF-Lalonde]: https://github.com/JF-Lalonde
+[@dalthon]: https://github.com/dalthon
 [@taylor-au]: https://github.com/taylor-au
 [@rabotyaga]: https://github.com/rabotyaga
 [@lowang]: https://github.com/lowang

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -142,7 +142,7 @@ module Chewy
         %i[import import!].each do |method|
           class_eval <<-METHOD, __FILE__, __LINE__ + 1
             def #{method}(*args)
-              return if args.first.blank? && !args.first.nil?
+              return true if args.first.blank? && !args.first.nil?
 
               options = args.extract_options!
               if args.one? && type_names.one?

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -284,7 +284,13 @@ describe Chewy::Index::Actions do
     specify 'with an empty array' do
       expect(CitiesIndex).not_to receive(:exists?)
       expect(CitiesIndex).not_to receive(:create!)
-      CitiesIndex.import([])
+      expect(CitiesIndex.import([])).to eq(true)
+    end
+
+    specify 'with an empty relation' do
+      expect(CitiesIndex).not_to receive(:exists?)
+      expect(CitiesIndex).not_to receive(:create!)
+      expect(CitiesIndex.import(City.where('1 = 2'))).to eq(true)
     end
 
     context do
@@ -314,7 +320,13 @@ describe Chewy::Index::Actions do
     specify 'with an empty array' do
       expect(CitiesIndex).not_to receive(:exists?)
       expect(CitiesIndex).not_to receive(:create!)
-      CitiesIndex.import!([])
+      expect(CitiesIndex.import!([])).to eq(true)
+    end
+
+    specify 'with an empty relation' do
+      expect(CitiesIndex).not_to receive(:exists?)
+      expect(CitiesIndex).not_to receive(:create!)
+      expect(CitiesIndex.import!(City.where('1 = 2'))).to eq(true)
     end
 
     context do


### PR DESCRIPTION
Just a rebase of #698 with one more spec added to cover empty relations.