### PR TITLE
Add support for direct_import parameter to skip objects reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Changes
 
+  * [#753](https://github.com/toptal/chewy/pull/753): Add support for direct_import parameter to skip objects reloading ([@TikiTDO][][@dalthon][])
   * [#739](https://github.com/toptal/chewy/pull/739): Remove explicit `main` branch dependencies on rspec* gems after `rspec-mocks` 3.10.2 is released ([@rabotyaga][])
 
 # Version 5.2.0 (2021-01-28)
@@ -572,6 +573,7 @@
 [@sharkzp]: https://github.com/@sharkzp
 [@socialchorus]: https://github.com/socialchorus
 [@taylor-au]: https://github.com/taylor-au
+[@TikiTDO]: https://github.com/TikiTDO
 [@undr]: https://github.com/@undr
 [@webgago]: https://github.com/@webgago
 [@yahooguntu]: https://github.com/yahooguntu

--- a/lib/chewy/type.rb
+++ b/lib/chewy/type.rb
@@ -14,7 +14,10 @@ require 'chewy/type/witchcraft'
 
 module Chewy
   class Type
-    IMPORT_OPTIONS_KEYS = %i[batch_size bulk_size refresh consistency replication raw_import journal pipeline].freeze
+    IMPORT_OPTIONS_KEYS = %i[
+      batch_size bulk_size consistency direct_import journal
+      pipeline raw_import refresh replication
+    ].freeze
 
     include Search
     include Mapping

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -67,6 +67,7 @@ module Chewy
         # @option options [String] suffix an index name suffix, used for zero-downtime reset mostly, no suffix by default
         # @option options [Integer] bulk_size bulk API chunk size in bytes; if passed, the request is performed several times for each chunk, empty by default
         # @option options [Integer] batch_size passed to the adapter import method, used to split imported objects in chunks, 1000 by default
+        # @option options [Boolean] direct_import skips object reloading in ORM adapter, `false` by default
         # @option options [true, false] journal enables imported objects journaling, false by default
         # @option options [Array<Symbol, String>] update_fields list of fields for the partial import, empty by default
         # @option options [true, false] update_failover enables full objects reimport in cases of partial update errors, `true` by default

--- a/spec/chewy/type/adapter/active_record_spec.rb
+++ b/spec/chewy/type/adapter/active_record_spec.rb
@@ -86,7 +86,19 @@ describe Chewy::Type::Adapter::ActiveRecord, :active_record do
           .to eq([{index: cities.first(2)}, {index: cities.last(1)}])
       end
 
-      specify { expect(import(cities)).to eq([{index: cities}]) }
+      specify do
+        cities
+        expects_db_queries do
+          expect(import(cities, direct_import: false)).to eq([{index: cities}])
+        end
+      end
+      specify do
+        cities
+        expects_no_query do
+          expect(import(cities, direct_import: true)).to eq([{index: cities}])
+        end
+      end
+
       specify do
         expect(import(cities, batch_size: 2))
           .to eq([{index: cities.first(2)}, {index: cities.last(1)}])


### PR DESCRIPTION
Just a rebase of https://github.com/toptal/chewy/pull/637 with added spec and a small fix regarding id types