### PR TITLE
attribute_highlights returns an array of highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Bug fixes
 
+  * [#755](https://github.com/toptal/chewy/pull/755): attribute_highlights returns an array of highlights ([@musaffa][], [@dalthon][])
   * [#695](https://github.com/toptal/chewy/pull/695): Clear the scroll by id after completing scroll_batches ([@socialchorus][])
-  * [#749](https://github.com/toptal/chewy/pull/749): Avoid importing everything when given an empty relation ([@JF-Lalonde][][@dalthon][])
+  * [#749](https://github.com/toptal/chewy/pull/749): Avoid importing everything when given an empty relation ([@JF-Lalonde][], [@dalthon][])
   * [#736](https://github.com/toptal/chewy/pull/736): Fix nil children when using witchcraft ([@taylor-au][])
 
 ## Changes
 
-  * [#753](https://github.com/toptal/chewy/pull/753): Add support for direct_import parameter to skip objects reloading ([@TikiTDO][][@dalthon][])
+  * [#753](https://github.com/toptal/chewy/pull/753): Add support for direct_import parameter to skip objects reloading ([@TikiTDO][], [@dalthon][])
   * [#739](https://github.com/toptal/chewy/pull/739): Remove explicit `main` branch dependencies on rspec* gems after `rspec-mocks` 3.10.2 is released ([@rabotyaga][])
 
 # Version 5.2.0 (2021-01-28)
@@ -556,6 +557,7 @@
 [@mkcode]: https://github.com/@mkcode
 [@mrbrdo]: https://github.com/@mrbrdo
 [@mrzasa]: https://github.com/mrzasa
+[@musaffa]: https://github.com/musaffa
 [@nattfodd]: https://github.com/nattfodd
 [@okliv]: https://github.com/okliv
 [@olancheg]: https://github.com/olancheg

--- a/lib/chewy/type/wrapper.rb
+++ b/lib/chewy/type/wrapper.rb
@@ -49,6 +49,8 @@ module Chewy
         m = method.to_s
         if (name = highlight_name(m))
           highlight(name)
+        elsif (name = highlight_names(m))
+          highlights(name)
         elsif @attributes.key?(m)
           @attributes[m]
         elsif attribute_defined?(m)
@@ -60,7 +62,7 @@ module Chewy
 
       def respond_to_missing?(method, include_private = false)
         m = method.to_s
-        highlight_name(m) || @attributes.key?(m) || attribute_defined?(m) || super
+        highlight_name(m) || highlight_names(m) || @attributes.key?(m) || attribute_defined?(m) || super
       end
 
     private
@@ -69,12 +71,20 @@ module Chewy
         method.sub(/_highlight\z/, '') if method.end_with?('_highlight')
       end
 
+      def highlight_names(method)
+        method.sub(/_highlights\z/, '') if method.end_with?('_highlights')
+      end
+
       def attribute_defined?(attribute)
         self.class.root && self.class.root.children.find { |a| a.name.to_s == attribute }.present?
       end
 
       def highlight(attribute)
         _data['highlight'][attribute].first if highlight?(attribute)
+      end
+
+      def highlights(attribute)
+        _data['highlight'][attribute] if highlight?(attribute)
       end
 
       def highlight?(attribute)

--- a/spec/chewy/query_spec.rb
+++ b/spec/chewy/query_spec.rb
@@ -36,6 +36,7 @@ describe Chewy::Query do
       specify { expect(subject.offset(6).count).to eq(3) }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name).to eq('Name3') }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlight).to eq('<em>Name3</em>') }
+      specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first.name_highlights).to eq(['<em>Name3</em>']) }
       specify { expect(subject.query({}).highlight(fields: {name: {}}).first.name_highlight).to eq(nil) }
       specify { expect(subject.query(match: {name: 'name3'}).highlight(fields: {name: {}}).first._data['_source']['name']).to eq('Name3') }
       specify { expect(subject.types(:product).count).to eq(3) }

--- a/spec/chewy/type/wrapper_spec.rb
+++ b/spec/chewy/type/wrapper_spec.rb
@@ -63,6 +63,7 @@ describe Chewy::Type::Wrapper do
 
       it do
         is_expected.to respond_to(:name_highlight)
+          .and respond_to(:name_highlights)
           .and have_attributes(
             name: 'Martin',
             name_highlight: '<b>Mar</b>tin'


### PR DESCRIPTION
Just a rebase of https://github.com/toptal/chewy/pull/387

It also, instead of adding breaking change, adds a new method `*_highlights` that implements new behavior.