### PR TITLE
[FIX-716] Avoid fetching scope data to check if it is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+  * [#761](https://github.com/toptal/chewy/pull/761): Avoid fetching scope data to check if it is blank ([@dalthon][])
+
 ### Bugs Fixed
 
 ## 6.0.0 (2021-02-11)

--- a/lib/chewy/type/import.rb
+++ b/lib/chewy/type/import.rb
@@ -127,7 +127,8 @@ module Chewy
       private
 
         def import_routine(*args)
-          return if args.first.blank? && !args.first.nil?
+          return if !args.first.nil? && empty_objects_or_scope?(args.first)
+
           routine = Routine.new(self, **args.extract_options!)
           routine.create_indexes!
 
@@ -135,6 +136,14 @@ module Chewy
             import_parallel(args, routine)
           else
             import_linear(args, routine)
+          end
+        end
+
+        def empty_objects_or_scope?(objects_or_scope)
+          if objects_or_scope.respond_to?(:empty?)
+            objects_or_scope.empty?
+          else
+            objects_or_scope.blank?
           end
         end
 

--- a/spec/chewy/type/import_spec.rb
+++ b/spec/chewy/type/import_spec.rb
@@ -158,6 +158,15 @@ describe Chewy::Type::Import do
         specify do
           expect { import City.where(id: dummy_cities.first.id) }.to update_index(CitiesIndex::City).and_reindex(dummy_cities.first).only
         end
+
+        specify do
+          allow(CitiesIndex::City).to receive(:import_linear).and_return(double(present?: false))
+          allow(CitiesIndex::City).to receive(:import_parallel).and_return(double(present?: false))
+
+          expects_no_query(except: /SELECT\s+1\s+AS\s+one\s+FROM/) do
+            import City.where(id: dummy_cities.first.id)
+          end
+        end
       end
     end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -39,14 +39,15 @@ module ActiveRecordClassHelpers
     raise 'Expected some db queries, but none were made' unless have_queries
   end
 
-  def expects_no_query(&block)
+  def expects_no_query(except: nil, &block)
     queries = []
     ActiveSupport::Notifications.subscribed(
       ->(*args) { queries << args[4][:sql] },
       'sql.active_record',
       &block
     )
-    raise "Expected no DB queries, but the following ones were made: #{queries.join(', ')}" if queries.present?
+    ofending_queries = except ? queries.find_all { |query| !query.match(except) } : queries
+    raise "Expected no DB queries, but the following ones were made: #{ofending_queries.join(', ')}" if ofending_queries.present?
   end
 
   def stub_model(name, superclass = nil, &block)


### PR DESCRIPTION
Address the issue raised here: https://github.com/toptal/chewy/issues/716

There was some unnecessary, possibly heavy, queries being done.

----------------

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
