### PR TITLE
[Fix #722] Remove alias_method_chain, use Module#prepend instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+  * [#722](https://github.com/toptal/chewy/issues/722): Remove alias_method_chain, use Module#prepend instead ([@dalthon][])
+
 ## 7.0.0 (2021-02-22)
 
 ### New Features

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -22,17 +22,6 @@ module Chewy
     end
 
     module MigrationStrategy
-      extend ActiveSupport::Concern
-      included do
-        alias_method_chain :migrate, :chewy
-      end
-
-      def migrate_with_chewy(*args)
-        Chewy.strategy(:bypass) { migrate_without_chewy(*args) }
-      end
-    end
-
-    module Rails5MigrationStrategy
       def migrate(*args)
         Chewy.strategy(:bypass) { super }
       end
@@ -57,13 +46,8 @@ module Chewy
 
     initializer 'chewy.migration_strategy' do
       ActiveSupport.on_load(:active_record) do
-        if Rails::VERSION::MAJOR >= 5
-          ActiveRecord::Migration.prepend(Rails5MigrationStrategy)
-          ActiveRecord::Migrator.prepend(Rails5MigrationStrategy) if defined? ActiveRecord::Migrator
-        else
-          ActiveRecord::Migration.send(:include, MigrationStrategy)
-          ActiveRecord::Migrator.send(:include, MigrationStrategy) if defined? ActiveRecord::Migrator
-        end
+        ActiveRecord::Migration.prepend(MigrationStrategy)
+        ActiveRecord::Migrator.prepend(MigrationStrategy) if defined? ActiveRecord::Migrator
       end
     end
 


### PR DESCRIPTION
Ruby 2.0 already have a better alternative to `alias_method_chain` which is `Module#prepend`. (Don't remember exactly when introduced).

There is no reason to continue using `alias_method_chain`, and it was causing some conflicts with other gems.

## Checklist

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. (not applicable)
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
