### PR TITLE
[Fix #495] Default rails console strategy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@
 
 ### Changes
 
-  * [#780](https://github.com/toptal/chewy/pull/780): Changing default console strategy ([@Vitalina-Vakulchyk][]):
-    * ability to set default console strategy with `Chewy.console_strategy`
-    * `:urgent` is used by default if `Chewy.console_strategy` is not set
+  * [#495](https://github.com/toptal/chewy/issues/495): Ability to change Rails console strategy with `Chewy.console_strategy` ([@Vitalina-Vakulchyk][])
   * [#778](https://github.com/toptal/chewy/pull/778): **(Breaking)** Drop support for Ruby 2.5 ([@Vitalina-Vakulchyk][])
   * [#776](https://github.com/toptal/chewy/pull/776): **(Breaking)** Removal of unnecessary features and integrations ([@Vitalina-Vakulchyk][]):
     * `aws-sdk-sqs` / `shoryuken`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@
 
 ### Changes
 
-  * [#778](https://github.com/toptal/chewy/pull/778): **(Breaking)** Drop support for Ruby 2.5 ([@Vitalina-Vakulchyk][]):
+  * [#780](https://github.com/toptal/chewy/pull/780): Changing default console strategy ([@Vitalina-Vakulchyk][]):
+    * ability to set default console strategy with `Chewy.console_strategy`
+    * `:urgent` is used by default if `Chewy.console_strategy` is not set
+
+  * [#778](https://github.com/toptal/chewy/pull/778): **(Breaking)** Drop support for Ruby 2.5 ([@Vitalina-Vakulchyk][])
+
   * [#776](https://github.com/toptal/chewy/pull/776): **(Breaking)** Removal of unnecessary features and integrations ([@Vitalina-Vakulchyk][]):
     * `aws-sdk-sqs` / `shoryuken`
     * `mongoid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@
   * [#780](https://github.com/toptal/chewy/pull/780): Changing default console strategy ([@Vitalina-Vakulchyk][]):
     * ability to set default console strategy with `Chewy.console_strategy`
     * `:urgent` is used by default if `Chewy.console_strategy` is not set
-
   * [#778](https://github.com/toptal/chewy/pull/778): **(Breaking)** Drop support for Ruby 2.5 ([@Vitalina-Vakulchyk][])
-
   * [#776](https://github.com/toptal/chewy/pull/776): **(Breaking)** Removal of unnecessary features and integrations ([@Vitalina-Vakulchyk][]):
     * `aws-sdk-sqs` / `shoryuken`
     * `mongoid`

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -20,7 +20,8 @@ module Chewy
                   #
                   :console_strategy,
                   # Allows to set default console strategy.
-                  # `:urgent` by default.
+                  # `:urgent` is used by default if `console_strategy` is not set
+                  #
                   :use_after_commit_callbacks,
                   # Where Chewy expects to find index definitions
                   # within a Rails app folder.

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -13,9 +13,6 @@ module Chewy
                   # for more info.
                   #
                   :request_strategy,
-                  # Current request strategy middleware
-                  #
-                  :strategy,
                   # Use after_commit callbacks for RDBMS instead of
                   # after_save and after_destroy. True by default. Useful
                   # in tests with transactional fixtures or transactional

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -13,6 +13,9 @@ module Chewy
                   # for more info.
                   #
                   :request_strategy,
+                  # Current request strategy middleware
+                  #
+                  :strategy,
                   # Use after_commit callbacks for RDBMS instead of
                   # after_save and after_destroy. True by default. Useful
                   # in tests with transactional fixtures or transactional

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -19,6 +19,8 @@ module Chewy
                   # DatabaseCleaner strategy.
                   #
                   :console_strategy,
+                  # Allows to set default console strategy.
+                  # `:urgent` by default.
                   :use_after_commit_callbacks,
                   # Where Chewy expects to find index definitions
                   # within a Rails app folder.

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -18,6 +18,7 @@ module Chewy
                   # in tests with transactional fixtures or transactional
                   # DatabaseCleaner strategy.
                   #
+                  :console_strategy,
                   :use_after_commit_callbacks,
                   # Where Chewy expects to find index definitions
                   # within a Rails app folder.

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -13,8 +13,7 @@ module Chewy
                   # for more info.
                   #
                   :request_strategy,
-                  # Default console strategy.
-                  # `:urgent` is used by default if `console_strategy` is not set.
+                  # Rails console strategy, `:urgent` by default.
                   #
                   :console_strategy,
                   # Use after_commit callbacks for RDBMS instead of

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -13,14 +13,14 @@ module Chewy
                   # for more info.
                   #
                   :request_strategy,
+                  # Default console strategy.
+                  # `:urgent` is used by default if `console_strategy` is not set.
+                  #
+                  :console_strategy,
                   # Use after_commit callbacks for RDBMS instead of
                   # after_save and after_destroy. True by default. Useful
                   # in tests with transactional fixtures or transactional
                   # DatabaseCleaner strategy.
-                  #
-                  :console_strategy,
-                  # Allows to set default console strategy.
-                  # `:urgent` is used by default if `console_strategy` is not set
                   #
                   :use_after_commit_callbacks,
                   # Where Chewy expects to find index definitions

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -53,6 +53,7 @@ module Chewy
       @settings = {}
       @root_strategy = :base
       @request_strategy = :atomic
+      @console_strategy = :urgent
       @use_after_commit_callbacks = true
       @reset_disable_refresh_interval = false
       @reset_no_replicas = false

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -36,8 +36,9 @@ module Chewy
     console do |app|
       if app.sandbox?
         Chewy.strategy(:bypass)
-      elsif !Chewy.strategy
-        Chewy.strategy(:urgent)
+      else
+        strategy = Chewy.console_strategy || :urgent
+        Chewy.strategy(strategy)
       end
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"
     end

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -37,9 +37,10 @@ module Chewy
       if app.sandbox?
         Chewy.strategy(:bypass)
       else
-        strategy = Chewy.console_strategy || :urgent
+        strategy = Chewy.console_strategy
         Chewy.strategy(strategy)
       end
+
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"
     end
 

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -39,7 +39,6 @@ module Chewy
       else
         Chewy.strategy(Chewy.console_strategy)
       end
-
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"
     end
 

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -37,8 +37,7 @@ module Chewy
       if app.sandbox?
         Chewy.strategy(:bypass)
       else
-        strategy = Chewy.console_strategy
-        Chewy.strategy(strategy)
+        Chewy.strategy(Chewy.console_strategy)
       end
 
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -34,8 +34,10 @@ module Chewy
     end
 
     console do |app|
-      if app.sandbox? || !Chewy.strategy
+      if app.sandbox?
         Chewy.strategy(:bypass)
+      elsif !Chewy.strategy
+        Chewy.strategy(:urgent)
       end
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"
     end

--- a/lib/chewy/railtie.rb
+++ b/lib/chewy/railtie.rb
@@ -34,10 +34,8 @@ module Chewy
     end
 
     console do |app|
-      if app.sandbox?
+      if app.sandbox? || !Chewy.strategy
         Chewy.strategy(:bypass)
-      else
-        Chewy.strategy(:urgent)
       end
       puts "Chewy console strategy is `#{Chewy.strategy.current.name}`"
     end

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -8,6 +8,7 @@ describe Chewy::Config do
   its(:transport_logger) { should be_nil }
   its(:root_strategy) { should == :base }
   its(:request_strategy) { should == :atomic }
+  its(:console_strategy) { should == :urgent }
   its(:use_after_commit_callbacks) { should == true }
   its(:indices_path) { should == 'app/chewy' }
   its(:reset_disable_refresh_interval) { should == false }

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -95,4 +95,15 @@ describe Chewy::Config do
       end
     end
   end
+
+  describe '.console_strategy' do
+    context 'sets .console_strategy' do
+      let(:strategy) { :atomic }
+
+      specify do
+        expect { subject.console_strategy = strategy }
+          .to change { subject.console_strategy }.to(strategy)
+      end
+    end
+  end
 end

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -98,11 +98,13 @@ describe Chewy::Config do
 
   describe '.console_strategy' do
     context 'sets .console_strategy' do
-      let(:strategy) { :atomic }
+      let(:default_strategy) { subject.console_strategy }
+      let(:new_strategy) { :atomic }
+      after { subject.console_strategy = default_strategy }
 
       specify do
-        expect { subject.console_strategy = strategy }
-          .to change { subject.console_strategy }.to(strategy)
+        expect { subject.console_strategy = new_strategy }
+          .to change { subject.console_strategy }.to(new_strategy)
       end
     end
   end


### PR DESCRIPTION
Remove default setting of :urgent strategy for console if there is another current strategy.

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] ~~Updated tests.~~
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
