### PR TITLE
fix a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ docker run --rm --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.t
 
 ### Index
 
-Create `app/chewy/user_index.rb` with User Index:
+Create `app/chewy/users_index.rb` with User Index:
 
 ```ruby
 class UsersIndex < Chewy::Index


### PR DESCRIPTION
Fixed a typo in readme for chewy index filename user_index.rb which gives an error. The right filename is users_index.rb