### PR TITLE
Prepare 7.0.1 release with skipped ES cluster version memoization for search requests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on: [push]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6, 2.7]
+        gemfile: [rails.5.2.activerecord, rails.6.0.activerecord, rails.6.1.activerecord]
+    name: ${{ matrix.ruby }}-${{ matrix.gemfile }}
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 7.10.1
+          port: 9250
+      - name: Tests
+        run: bundle exec rspec
+
+  ruby-3-0-activerecord-6-1:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails.6.1.activerecord.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+      - name: Run Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 7.10.1
+          port: 9250
+      - name: Tests
+        run: bundle exec rspec
+
+  ruby-3-0-activerecord-6-1-es6:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails.6.1.activerecord.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+      - name: Run Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 6.8.15
+          port: 9250
+      - name: Tests
+        run: bundle exec rspec
+
+  ruby-2-7-activerecord-6-1-es6:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails.6.1.activerecord.gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Run Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 6.8.15
+          port: 9250
+      - name: Tests
+        run: bundle exec rspec
+
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rubocop --format simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ### Bugs Fixed
 
+## 7.0.1 (2021-05-03)
+
+### Changes
+
+  * [#792](https://github.com/toptal/chewy/pull/792): Skip ES version memoization for search requests ([@rabotyaga][])
+    * See the Migration Guide for details
+
 ## 7.0.0 (2021-02-22)
 
 ### New Features

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -990,7 +990,7 @@ module Chewy
 
       def perform(additional = {})
         request_body = render.merge(additional)
-        request_body[:rest_total_hits_as_int] = true if Runtime.version >= '7.0.0'
+        request_body[:rest_total_hits_as_int] = true if Chewy::Runtime::Version.new(Chewy.client.info['version']['number']) >= '7.0.0'
         ActiveSupport::Notifications.instrument 'search_query.chewy',
           notification_payload(request: request_body) do
             begin

--- a/lib/chewy/version.rb
+++ b/lib/chewy/version.rb
@@ -1,3 +1,3 @@
 module Chewy
-  VERSION = '7.0.0'.freeze
+  VERSION = '7.0.1'.freeze
 end

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -10,10 +10,32 @@ In order to upgrade Chewy 6/Elasticsearch 6 to Chewy 7/Elasticsearch 7 in the mo
 
 * Upgrade to the latest 6.x stable releases, namely Chewy 6.0, Elasticsearch 6.8
 * Study carefully [Breaking changes in 7.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.htmll), make sure your application conforms.
-* Run your test suite on Chewy 7 / Elasticsearch 7
-* Run manual tests on Chewy 7 / Elasticsearch 7
-* Upgrade to Chewy 7
+* Run your test suite on Chewy 7.0 / Elasticsearch 7
+* Run manual tests on Chewy 7.0 / Elasticsearch 7
+* Upgrade to Chewy 7.0
+  * The “total hits” counter is an integer for ES versions < 7 and an object (hash) for the versions starting from 7.0.0. Elasticsearch added a special option, `rest_total_hits_as_int`, to ease the upgrade, that could be appended to any request and results in the old “total hits” format. Unfortunately, this option is not recognized by ES versions prior to 7.0.0, which means that we have to check the version to decide if we need this option.
+    Normally Chewy does memoization of the current ES version, but this might be inappropriate for the upgrade, as the version changes live.
+    To handle that we have 2 versions of Chewy for this stage of the upgrade: 7.0.0 and 7.0.1. Version 7.0.0 does the memoization and version 7.0.1 requests the current version on every search request. 
+  * You can use the 7.0.0 version if it's fine for you to have an application restart immediately after ES cluster upgrade.
+  * If you're using the 7.0.1 version you might be interested in keeping the timeframe between this step and the last one as small as possible, as version 7.0.1 skips ES version memoization for search requests to help dynamically detect ES version. This leads to an extra version request on each search request, i.e. could affect the overall performance/latency of the search and a load of ES cluster.
 * Perform a [rolling upgrade](https://www.elastic.co/guide/en/elasticsearch/reference//rolling-upgrades.html) of Elasticsearch
+* Run your test suite on Chewy 7.1 / Elasticsearch 7
+* Run manual tests on Chewy 7.1 / Elasticsearch 7
+* Upgrade to Chewy 7.1
+* Upgrade to Chewy 7.2:
+  * Remove all the the `Chewy::Type` class usages, e.g. remove `CitiesIndex::City` / `CitiesIndex.city`
+    * `CitiesIndex::City.import! ...` becomes `CitiesIndex.import! ...`
+  * Update indexes with simplified DSL:
+    * `define_type` block -> `index_scope` clause
+      * it can be omitted completely, if you don't need to specify the scope or options, e.g. `name`
+  * Remove type names from string representations:
+    * in `update_index` ActiveRecord helper and RSpec matcher, e.g.
+      * `update_index('cities#city')` -> `update_index('cities')`
+      * `update_index(UsersIndex::User)` -> `update_index(UsersIndex)`
+    * in rake tasks (e.g. `rake chewy:update[cities#city]` -> `rake chewy:update[cities]`)
+    * rake tasks output is also changed (e.g. `Imported CitiesIndex::City in 1s, stats: index 3` -> `Imported CitiesIndex in 1s, stats: index 3`)
+  * Use index name instead of type name in loader additional scope
+    * e.g. `CitiesIndex.filter(...).load(city: {scope: City.where(...)})` -> `CitiesIndex.filter(...).load(cities: {scope: City.where(...)})`
 
 ## Chewy 5/Elasticsearch 5 to Chewy 6/Elasticsearch 6
 


### PR DESCRIPTION
The “total hits” counter is an integer for ES versions < 7 and an object (hash) for the versions starting from 7.0.0. Elasticsearch added a special option, `rest_total_hits_as_int`, to ease the upgrade, that could be appended to any request and results in the old “total hits” format. Unfortunately, this option is not recognized by ES versions prior to 7.0.0, which means that we have to check the version to decide if we need this option.

Normally Chewy does memoization of the current ES version, but this might be inappropriate for the upgrade, as the version changes live.

Release the v7.0.1 Chewy version to allow dynamically detect the current Elasticsearch version.
More details in the Migration Guide.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* (n/a) Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* (n/a) Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
