### PR TITLE
Use Chewy.thread_local_data to access Thread.current

### DIFF
--- a/lib/chewy/runtime.rb
+++ b/lib/chewy/runtime.rb
@@ -3,7 +3,7 @@ require 'chewy/runtime/version'
 module Chewy
   module Runtime
     def self.version
-      Thread.current[:chewy_runtime_version] ||= Version.new(Chewy.client.info['version']['number'])
+      Chewy.thread_local_data[:chewy_runtime_version] ||= Version.new(Chewy.client.info['version']['number'])
     end
   end
 end

--- a/lib/chewy/search/scoping.rb
+++ b/lib/chewy/search/scoping.rb
@@ -29,7 +29,7 @@ module Chewy
         #
         # @return [Array<Chewy::Search::Request>] array of scopes
         def scopes
-          Thread.current[:chewy_scopes] ||= []
+          Chewy.thread_local_data[:chewy_scopes] ||= []
         end
       end
 

--- a/spec/chewy_spec.rb
+++ b/spec/chewy_spec.rb
@@ -50,13 +50,13 @@ describe Chewy do
   end
 
   describe '.client' do
-    let!(:initial_client) { Thread.current[:chewy_client] }
+    let!(:initial_client) { Chewy.thread_local_data[:chewy_client] }
     let(:faraday_block) { proc {} }
     let(:mock_client) { double(:client) }
     let(:expected_client_config) { {transport_options: {}} }
 
     before do
-      Thread.current[:chewy_client] = nil
+      Chewy.thread_local_data[:chewy_client] = nil
       allow(Chewy).to receive_messages(configuration: {transport_options: {proc: faraday_block}})
 
       allow(::Elasticsearch::Client).to receive(:new).with(expected_client_config) do |*_args, &passed_block|
@@ -70,7 +70,7 @@ describe Chewy do
 
     its(:client) { is_expected.to eq(mock_client) }
 
-    after { Thread.current[:chewy_client] = initial_client }
+    after { Chewy.thread_local_data[:chewy_client] = initial_client }
   end
 
   describe '.create_indices' do


### PR DESCRIPTION
Currently, it's dangerous to use Chewy with dry-effects, because it runs fibers that reset Thread local state.  This PR isolates thread-local variables access, so it could be easily extended. 

After isolating them, we can provide dry-effects integration. 

See https://github.com/dry-rb/dry-effects/issues/82 for the details. 


Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
