### PR TITLE
Rename Chewy.thread_local_data to Chewy.current

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -64,7 +64,7 @@ module Chewy
 
     # A thread-local variables accessor
     # @return [Hash]
-    def thread_local_data
+    def current
       Thread.current[:chewy] ||= {}
     end
 
@@ -92,7 +92,7 @@ module Chewy
     # Main elasticsearch-ruby client instance
     #
     def client
-      Chewy.thread_local_data[:chewy_client] ||= begin
+      Chewy.current[:chewy_client] ||= begin
         client_configuration = configuration.deep_dup
         client_configuration.delete(:prefix) # used by Chewy, not relevant to Elasticsearch::Client
         block = client_configuration[:transport_options].try(:delete, :proc)
@@ -144,15 +144,15 @@ module Chewy
     #   city3.do_update! # index updated again
     #
     def strategy(name = nil, &block)
-      Chewy.thread_local_data[:chewy_strategy] ||= Chewy::Strategy.new
+      Chewy.current[:chewy_strategy] ||= Chewy::Strategy.new
       if name
         if block
-          Chewy.thread_local_data[:chewy_strategy].wrap name, &block
+          Chewy.current[:chewy_strategy].wrap name, &block
         else
-          Chewy.thread_local_data[:chewy_strategy].push name
+          Chewy.current[:chewy_strategy].push name
         end
       else
-        Chewy.thread_local_data[:chewy_strategy]
+        Chewy.current[:chewy_strategy]
       end
     end
 

--- a/lib/chewy/runtime.rb
+++ b/lib/chewy/runtime.rb
@@ -3,7 +3,7 @@ require 'chewy/runtime/version'
 module Chewy
   module Runtime
     def self.version
-      Chewy.thread_local_data[:chewy_runtime_version] ||= Version.new(Chewy.client.info['version']['number'])
+      Chewy.current[:chewy_runtime_version] ||= Version.new(Chewy.client.info['version']['number'])
     end
   end
 end

--- a/lib/chewy/search/scoping.rb
+++ b/lib/chewy/search/scoping.rb
@@ -29,7 +29,7 @@ module Chewy
         #
         # @return [Array<Chewy::Search::Request>] array of scopes
         def scopes
-          Chewy.thread_local_data[:chewy_scopes] ||= []
+          Chewy.current[:chewy_scopes] ||= []
         end
       end
 

--- a/spec/chewy_spec.rb
+++ b/spec/chewy_spec.rb
@@ -50,13 +50,13 @@ describe Chewy do
   end
 
   describe '.client' do
-    let!(:initial_client) { Chewy.thread_local_data[:chewy_client] }
+    let!(:initial_client) { Chewy.current[:chewy_client] }
     let(:faraday_block) { proc {} }
     let(:mock_client) { double(:client) }
     let(:expected_client_config) { {transport_options: {}} }
 
     before do
-      Chewy.thread_local_data[:chewy_client] = nil
+      Chewy.current[:chewy_client] = nil
       allow(Chewy).to receive_messages(configuration: {transport_options: {proc: faraday_block}})
 
       allow(::Elasticsearch::Client).to receive(:new).with(expected_client_config) do |*_args, &passed_block|
@@ -70,7 +70,7 @@ describe Chewy do
 
     its(:client) { is_expected.to eq(mock_client) }
 
-    after { Chewy.thread_local_data[:chewy_client] = initial_client }
+    after { Chewy.current[:chewy_client] = initial_client }
   end
 
   describe '.create_indices' do


### PR DESCRIPTION
We don't want to specify in the variable's name how the data is stored, to be able to change an underlying implementation easily.

Currently, the name is confusing: it says `thread_local_data`, but it stores values in fiber-local  🤷‍♂️

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
