### PR TITLE
Use thread-local variables instead of fiber-local variables to store global configuration.

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -65,20 +65,12 @@ module Chewy
     # A thread-local variables accessor
     # @return [Hash]
     def current
-      initialize_current_storage
-
-      current
-    end
-
-    # @api private
-    def initialize_current_storage
-      Thread.current.thread_variable_set(:chewy, {})
-
-      define_singleton_method(:current) do
-        Thread.current.thread_variable_get(:chewy)
+      unless Thread.current.thread_variable?(:chewy)
+        Thread.current.thread_variable_set(:chewy, {})
       end
+
+      Thread.current.thread_variable_get(:chewy)
     end
-    private :initialize_current_storage
 
     # Derives an index for the passed string identifier if possible.
     #

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -65,8 +65,20 @@ module Chewy
     # A thread-local variables accessor
     # @return [Hash]
     def current
-      Thread.current[:chewy] ||= {}
+      initialize_current_storage
+
+      current
     end
+
+    # @api private
+    def initialize_current_storage
+      Thread.current.thread_variable_set(:chewy, {})
+
+      define_singleton_method(:current) do
+        Thread.current.thread_variable_get(:chewy)
+      end
+    end
+    private :initialize_current_storage
 
     # Derives an index for the passed string identifier if possible.
     #


### PR DESCRIPTION
Use thread-local variables instead of fiber-local variables to store global configuration.

1. Currently, we’re using fiber-local variables. This is indistinguishable from the pre-ruby-1.9 thread-local variables, unless you use fibers and use chewy in those fibers. But if you do - all fiber-local variables are extinguished inside any fiber, explicitly created by `Fiber.new`.
2. If we switch to thread-local variables - i.e. `thread_variable_get/thread_variable_set` - we’re fixing the issue with variables presence inside explicitly created fibers, but introducing a potential issue of having a mess between fibers of one thread, if one decides to use different clients or different strategies in different fibers.
3. If we continue to use fiber-local variables and add a patch on the dry-effects side this fixes the [issue with the dry-effects](https://github.com/dry-rb/dry-effects/issues/82), but a more general case is left unhandled, and, what sounds particularly bad to me, we’re introducing coupling between 2 completely unrelated gems.

As we discussed with @kml and @rabotyaga, we're changing fiber-local to thread-local for now because it's unlikely it may affect anyone using chewy in any negative way.  If this rare use case bubbles up later - we can address it by introducing a configuration option. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
