### PR TITLE
Fixate elasticsearch gem version < 7.14.0

### DIFF
--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency 'unparser'
 
   spec.add_dependency 'activesupport', '>= 5.2'
-  spec.add_dependency 'elasticsearch', '>= 7.12.0'
+  spec.add_dependency 'elasticsearch', '>= 7.12.0', '< 7.14.0'
   spec.add_dependency 'elasticsearch-dsl'
 end


### PR DESCRIPTION
We need to avoid elasticsearch gem versions >= 7.14.0 for now.
We have some specs failure with it: https://github.com/toptal/chewy/runs/3240650016
Probably related to https://github.com/elastic/elasticsearch-ruby/blob/master/CHANGELOG.md#client
Also, there are more changes and client can refuse to talk to a server of certain builds (`The client noticed that the server is not a supported distribution of Elasticsearch`), more info: https://github.com/elastic/elasticsearch-py/issues/1639


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* (n/a) Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* (n/a) Added tests.
* (n/a) Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
