### PR TITLE
fix: change gha version to SHA

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@master
+        uses: elastic/elastic-github-actions/elasticsearch@9de0f78f306e4ebc0838f057e6b754364685e759
         with:
           stack-version: 7.10.1
           port: 9250
@@ -40,7 +40,7 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
       - name: Run Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@master
+        uses: elastic/elastic-github-actions/elasticsearch@9de0f78f306e4ebc0838f057e6b754364685e759
         with:
           stack-version: 7.10.1
           port: 9250


### PR DESCRIPTION
[CI-601](https://toptal-core.atlassian.net/browse/CI-601)
Using master as as version of 3rd party GitHub action is a potential security risk.
We are changing from:
`uses: elastic/elastic-github-actions/elasticsearch@master`
to:
`uses: elastic/elastic-github-actions/elasticsearch@<SHA-key>`
What I did is just went to the repository, and got the latest SHA of the master.
3rd party GHA repositories changed within this PR:

- [https://github.com/toptal/chewy](url)

How to test

- Green check on this PR is enough

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* ~[ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.~

[1]: https://chris.beams.io/posts/git-commit/
