### PR TITLE
Move preference to query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 ### Bugs Fixed
+  * [#816](https://github.com/toptal/chewy/pull/816): Move query [`preference`](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-search.html#search-preference) from body to query parameters. ([@afg419][])
 
 ## 7.2.2 (2021-05-24)
 
@@ -624,6 +625,7 @@
 [@aglushkov]: https://github.com/aglushkov
 [@AlexVPopov]: https://github.com/AlexVPopov
 [@AndreySavelyev]: https://github.com/AndreySavelyev
+[@afg419]: https://github.com/afg419
 [@arion]: https://github.com/arion
 [@arturtr]: https://github.com/arturtr
 [@averell23]: https://github.com/averell23

--- a/lib/chewy/search/parameters.rb
+++ b/lib/chewy/search/parameters.rb
@@ -10,7 +10,7 @@ module Chewy
     # @see Chewy::Search::Request#parameters
     # @see Chewy::Search::Parameters::Storage
     class Parameters
-      QUERY_STRING_STORAGES = %i[indices search_type request_cache allow_partial_search_results].freeze
+      QUERY_STRING_STORAGES = %i[indices preference search_type request_cache allow_partial_search_results].freeze
 
       # Default storage classes warehouse. It is probably possible to
       # add your own classes here if necessary, but I'm not sure it will work.

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -214,13 +214,18 @@ describe Chewy::Search::Request do
     specify { expect { subject.search_type('foo') }.not_to change { subject.render } }
   end
 
-  %i[preference timeout].each do |name|
-    describe "##{name}" do
-      specify { expect(subject.send(name, :foo).render[:body]).to include(name => 'foo') }
-      specify { expect(subject.send(name, :foo).send(name, :bar).render[:body]).to include(name => 'bar') }
-      specify { expect(subject.send(name, :foo).send(name, nil).render[:body]).to be_blank }
-      specify { expect { subject.send(name, :foo) }.not_to change { subject.render } }
-    end
+  describe '#preference' do
+    specify { expect(subject.preference('foo').render).to include(preference: 'foo') }
+    specify { expect(subject.preference('foo').preference('bar').render).to include(preference: 'bar') }
+    specify { expect(subject.preference('foo').preference(nil).render[:preference]).to be_blank }
+    specify { expect { subject.preference('foo') }.not_to change { subject.render } }
+  end
+
+  describe "#timeout" do
+    specify { expect(subject.timeout(:foo).render[:body]).to include(timeout: 'foo') }
+    specify { expect(subject.timeout(:foo).timeout(:bar).render[:body]).to include(timeout: 'bar') }
+    specify { expect(subject.timeout(:foo).timeout(nil).render[:body]).to be_blank }
+    specify { expect { subject.timeout(:foo) }.not_to change { subject.render } }
   end
 
   describe '#source' do


### PR DESCRIPTION
This PR moves the preference parameter from the query body to the url as a query parameter. This is in accord with [elasticsearch 7 specification](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-shard-routing.html#shard-and-node-preference).

Current behavior:
```
PostIndex.preference(:_local).wrappers
#=> Elasticsearch::Transport::Transport::Errors::BadRequest ([400] {"error":{"root_cause":[{"type":"parsing_exception","reason":"Unknown key for a VALUE_STRING in [preference].","line":1,"col":15}],"type":"parsing_exception","reason":"Unknown key for a VALUE_STRING in [preference].","line":1,"col":15},"status":400})
```

New behavior post PR:
```
PostIndex.preference(:_local).wrappers
#=> stuff
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
