### PR TITLE
[Fix #825] Mismatch argument names at update_mapping rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+ * [#825](https://github.com/toptal/chewy/issues/825): Fix mismatch argument names at update_mapping rake task ([@AgeevAndrew][])
+
 ## 7.2.3 (2021-10-29)
 
 ### New Features
@@ -634,6 +636,7 @@
   * Initial version
 
 [@0x0badc0de]: https://github.com/0x0badc0de
+[@AgeevAndrew]: https://github.com/AgeevAndrew
 [@aglushkov]: https://github.com/aglushkov
 [@AlexVPopov]: https://github.com/AlexVPopov
 [@AndreySavelyev]: https://github.com/AndreySavelyev

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -54,7 +54,7 @@ namespace :chewy do
 
   desc 'Update mapping of exising index with body hash'
   task :update_mapping, %i[index_name] => :environment do |_task, args|
-    Chewy::RakeHelper.update_mapping(name: args[:name])
+    Chewy::RakeHelper.update_mapping(name: args[:index_name])
   end
 
   namespace :parallel do


### PR DESCRIPTION
The `update_mapping` rake task expected the argument, named `index_name`, however, another argument passed to the  `RakeHelper.update_mapping` method
 
