### PR TITLE
Fixed elasticsearch-dsl link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ You can query a set of indexes at once:
 CitiesIndex.indices(CountriesIndex).query(match: {name: 'Some'})
 ```
 
-See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html and https://github.com/elastic/elasticsearch-ruby/tree/master/elasticsearch-dsl for more details.
+See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html and https://github.com/elastic/elasticsearch-dsl-ruby for more details.
 
 An important part of requests manipulation is merging. There are 4 methods to perform it: `merge`, `and`, `or`, `not`. See [Chewy::Search::QueryProxy](lib/chewy/search/query_proxy.rb) for details. Also, `only` and `except` methods help to remove unneeded parts of the request.
 


### PR DESCRIPTION
A few days ago this PR was merged https://github.com/elastic/elasticsearch-ruby/pull/1624 meaning the link isn't working again. Now it's pointing to the `elasticsearch-dsl-ruby` repository
