### PR TITLE
Add ActiveRecord 7 and Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,15 +29,22 @@ jobs:
       - name: Tests
         run: bundle exec rspec
 
-  ruby-3-0-activerecord-6-1:
+  ruby-3-0-and-3-1:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', 3.1]
+        gemfile: [rails.6.1.activerecord, rails.7.0.activerecord]
+    name: ${{ matrix.ruby }}-${{ matrix.gemfile }}
+
     env:
-      BUNDLE_GEMFILE: gemfiles/rails.6.1.activerecord.gemfile
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run Elasticsearch
         uses: elastic/elastic-github-actions/elasticsearch@9de0f78f306e4ebc0838f057e6b754364685e759

--- a/gemfiles/rails.7.0.activerecord.gemfile
+++ b/gemfiles/rails.7.0.activerecord.gemfile
@@ -1,19 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'activejob', '~> 6.1.0'
-gem 'activerecord', '~> 6.1.0'
-gem 'activesupport', '~> 6.1.0'
+gem 'activejob', '~> 7.0.0'
+gem 'activerecord', '~> 7.0.0'
+gem 'activesupport', '~> 7.0.0'
 gem 'kaminari-core', '~> 1.1.0', require: false
 gem 'parallel', require: false
 gem 'rspec_junit_formatter', '~> 0.4.1'
 gem 'sidekiq', require: false
 
 gem 'rexml' if RUBY_VERSION >= '3.0.0'
-
-if RUBY_VERSION >= '3.1.0'
-  gem 'net-imap', require: false
-  gem 'net-pop', require: false
-  gem 'net-smtp', require: false
-end
 
 gemspec path: '../'

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/version'
 require 'active_support/concern'
 require 'active_support/deprecation'
@@ -14,18 +15,18 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/string/inflections'
 
-require 'i18n/core_ext/hash'
-require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
-require 'singleton'
-require 'base64'
-
-require 'elasticsearch'
-
 def try_require(path)
   require path
 rescue LoadError
   nil
 end
+
+try_require('i18n/core_ext/hash')
+require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
+require 'singleton'
+require 'base64'
+
+require 'elasticsearch'
 
 try_require 'kaminari'
 try_require 'kaminari/core'

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -15,18 +15,16 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/string/inflections'
 
+require 'singleton'
+require 'base64'
+
+require 'elasticsearch'
+
 def try_require(path)
   require path
 rescue LoadError
   nil
 end
-
-try_require('i18n/core_ext/hash')
-require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
-require 'singleton'
-require 'base64'
-
-require 'elasticsearch'
 
 try_require 'kaminari'
 try_require 'kaminari/core'

--- a/lib/chewy/rspec/update_index.rb
+++ b/lib/chewy/rspec/update_index.rb
@@ -1,4 +1,4 @@
-require 'i18n/core_ext/hash'
+try_require 'i18n/core_ext/hash'
 
 # Rspec matcher `update_index`
 # To use it - add `require 'chewy/rspec'` to the `spec_helper.rb`

--- a/lib/chewy/rspec/update_index.rb
+++ b/lib/chewy/rspec/update_index.rb
@@ -1,5 +1,3 @@
-try_require 'i18n/core_ext/hash'
-
 # Rspec matcher `update_index`
 # To use it - add `require 'chewy/rspec'` to the `spec_helper.rb`
 # Simple usage - just pass index as argument.


### PR DESCRIPTION
This PR adds Ruby 3.1 and ActiveRecord 7.0 to the CI matrix in the following combinations:

1. Ruby 3.0 / ActiveRecord 7.0
2. Ruby 3.1 / ActiveRecord 6.1
3. Ruby 3.1 / ActiveRecord 7.0

With the additional changes below, the new branches all run green.

In addition to the CI configuration updates, this PR includes the following changes:

1. Explicitly adding the net-imap, net-pop, and net-smtp gems to the Rails 6.1 gemfile when Ruby is 3.1 or higher
2. Tweaking a few requires so that class loading works correctly in Rails 7

I didn't add a CHANGELOG entry because I'm not sure if the maintainers would want to treat this PR as an expansion of the officially supported Ruby and ActiveRecord versions.

-----------------

Before submitting the PR make sure the following are checked:

* [X] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [X] Wrote [good commit messages][1].
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
