### PR TITLE
Explicitly use ActiveSupport hash extensions instead of i18n

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -13,8 +13,8 @@ require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/hash'
 
-require 'i18n/core_ext/hash'
 require 'chewy/backports/deep_dup' unless Object.respond_to?(:deep_dup)
 require 'singleton'
 require 'base64'

--- a/lib/chewy/rspec/update_index.rb
+++ b/lib/chewy/rspec/update_index.rb
@@ -1,4 +1,4 @@
-require 'i18n/core_ext/hash'
+require 'active_support/core_ext/hash'
 
 # Rspec matcher `update_index`
 # To use it - add `require 'chewy/rspec'` to the `spec_helper.rb`


### PR DESCRIPTION
Before 1.9.0, i18n provided a set of hash extensions, corresponding to a subset of ActiveSupport's hash extensions. Chewy included these in 2014, seemingly to support Rails 3.2: https://github.com/toptal/chewy/commit/0ab155468dcfb4a8aaeab56a00dbbcd6494d3625

Since 2018, this has in fact been doing nothing (and Chewy has been silently falling back to ActiveSupport), since i18n's core_ext/hash changed to a refinement rather than patching Hash: https://github.com/ruby-i18n/i18n/commit/949dc641d81773977e432626427aa0f8971a1073

Remove the require of i18n and explicitly require active_support/core_ext/hash.

Fixes #832

