### PR TITLE
Support keyword arguments in named scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+ * [#835](https://github.com/toptal/chewy/pull/835): Support keyword arguments in named scopes. ([@milk1000cc][])
+
 ## 7.2.4 (2022-02-03)
 
 ### New Features

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -84,8 +84,8 @@ module Chewy
       def delegate_scoped(source, destination, methods)
         methods.each do |method|
           destination.class_eval do
-            define_method method do |*args, &block|
-              scoping { source.public_send(method, *args, &block) }
+            define_method method do |*args, **kwargs, &block|
+              scoping { source.public_send(method, *args, **kwargs, &block) }
             end
           end
         end

--- a/spec/chewy/search_spec.rb
+++ b/spec/chewy/search_spec.rb
@@ -48,6 +48,10 @@ describe Chewy::Search do
           filter { match name: "Name#{index}" }
         end
 
+        def self.by_rating_with_kwargs(value, options:)
+          filter { match rating: value }
+        end
+
         index_scope City
         field :name, type: 'keyword'
         field :rating, type: :integer
@@ -114,5 +118,10 @@ describe Chewy::Search do
     specify { expect(CountriesIndex.by_rating(3).by_name(5).map(&:class)).to eq([CountriesIndex]) }
     specify { expect(CountriesIndex.order(:name).by_rating(3).map(&:rating)).to eq([3]) }
     specify { expect(CountriesIndex.order(:name).by_rating(3).map(&:class)).to eq([CountriesIndex]) }
+
+    specify 'supports keyword arguments' do
+      expect(CitiesIndex.by_rating_with_kwargs(3, options: 'blah blah blah').map(&:rating)).to eq([3])
+      expect(CitiesIndex.order(:name).by_rating_with_kwargs(3, options: 'blah blah blah').map(&:rating)).to eq([3])
+    end
   end
 end


### PR DESCRIPTION
This PR supports keyword arguments in named scopes.

In the current master version, an `ArgumentError` is raised.
Ruby version is 3.0.2.

```ruby
class UsersIndex < Chewy::Index
  def self.by_name(name, options:)
  end
end

UsersIndex.limit(10).by_name('Martin', options: 'blah blah blah')
# => wrong number of arguments (given 2, expected 1) (ArgumentError)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
