### PR TITLE
Fix keyword arguments handling in names scopes

### DIFF
--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -84,9 +84,10 @@ module Chewy
       def delegate_scoped(source, destination, methods)
         methods.each do |method|
           destination.class_eval do
-            define_method method do |*args, **kwargs, &block|
-              scoping { source.public_send(method, *args, **kwargs, &block) }
+            define_method method do |*args, &block|
+              scoping { source.public_send(method, *args, &block) }
             end
+            ruby2_keywords method
           end
         end
       end

--- a/spec/chewy/search_spec.rb
+++ b/spec/chewy/search_spec.rb
@@ -48,7 +48,7 @@ describe Chewy::Search do
           filter { match name: "Name#{index}" }
         end
 
-        def self.by_rating_with_kwargs(value, options:)
+        def self.by_rating_with_kwargs(value, options:) # rubocop:disable Lint/UnusedMethodArgument
           filter { match rating: value }
         end
 


### PR DESCRIPTION
Fixes errors introduced in https://github.com/toptal/chewy/pull/835
