### PR TITLE
Add collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+ * [#841](https://github.com/toptal/chewy/pull/841): Add the [`collapse`](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html) option to the request. ([@jkostolansky][])
+
 ### Changes
 
 ### Bugs Fixed
@@ -696,6 +698,7 @@
 [@jimmybaker]: https://github.com/jimmybaker
 [@jirikolarik]: https://github.com/jirikolarik
 [@jirutka]: https://github.com/jirutka
+[@jkostolansky]: https://github.com/jkostolansky
 [@joeljunstrom]: https://github.com/joeljunstrom
 [@jondavidford]: https://github.com/jondavidford
 [@joonty]: https://github.com/joonty

--- a/lib/chewy/search/parameters/collapse.rb
+++ b/lib/chewy/search/parameters/collapse.rb
@@ -1,0 +1,16 @@
+require 'chewy/search/parameters/storage'
+
+module Chewy
+  module Search
+    class Parameters
+      # Just a standard hash storage. Nothing to see here.
+      #
+      # @see Chewy::Search::Parameters::HashStorage
+      # @see Chewy::Search::Request#collapse
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
+      class Collapse < Storage
+        include HashStorage
+      end
+    end
+  end
+end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -24,7 +24,7 @@ module Chewy
         track_scores track_total_hits request_cache explain version profile
         search_type preference limit offset terminate_after
         timeout min_score source stored_fields search_after
-        load script_fields suggest aggs aggregations none
+        load script_fields suggest aggs aggregations collapse none
         indices_boost rescore highlight total total_count
         total_entries indices types delete_all count exists?
         exist? find pluck scroll_batches scroll_hits
@@ -41,7 +41,7 @@ module Chewy
       EXTRA_STORAGES = %i[aggs suggest].freeze
       # An array of storage names that are changing the returned hist collection in any way.
       WHERE_STORAGES = %i[
-        query filter post_filter none min_score rescore indices_boost
+        query filter post_filter none min_score rescore indices_boost collapse
       ].freeze
 
       delegate :hits, :wrappers, :objects, :records, :documents,
@@ -509,7 +509,18 @@ module Chewy
       #   @see https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-index.html#multi-index
       #   @param value [true, false, nil]
       #   @return [Chewy::Search::Request]
-      %i[request_cache search_type preference timeout limit offset terminate_after min_score ignore_unavailable].each do |name|
+      #
+      # @!method collapse(value)
+      #   Replaces the value of the `collapse` request part.
+      #
+      #   @example
+      #     PlacesIndex.collapse(field: :name)
+      #     # => <PlacesIndex::Query {..., :body=>{:collapse=>{"field"=>:name}}}>
+      #   @see Chewy::Search::Parameters::Collapse
+      #   @see https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
+      #   @param value [Hash]
+      #   @return [Chewy::Search::Request]
+      %i[request_cache search_type preference timeout limit offset terminate_after min_score ignore_unavailable collapse].each do |name|
         define_method name do |value|
           modify(name) { replace!(value) }
         end

--- a/spec/chewy/search/parameters/collapse_spec.rb
+++ b/spec/chewy/search/parameters/collapse_spec.rb
@@ -1,0 +1,5 @@
+require 'chewy/search/parameters/hash_storage_examples'
+
+describe Chewy::Search::Parameters::Collapse do
+  it_behaves_like :hash_storage, :collapse
+end

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -314,6 +314,16 @@ describe Chewy::Search::Request do
     end
   end
 
+  describe '#collapse' do
+    specify { expect(subject.collapse(foo: {bar: 42}).render[:body]).to include(collapse: {'foo' => {bar: 42}}) }
+    specify do
+      expect(subject.collapse(foo: {bar: 42}).collapse(moo: {baz: 43}).render[:body])
+        .to include(collapse: {'moo' => {baz: 43}})
+    end
+    specify { expect(subject.collapse(foo: {bar: 42}).collapse(nil).render[:body]).to be_blank }
+    specify { expect { subject.collapse(foo: {bar: 42}) }.not_to change { subject.render } }
+  end
+
   describe '#docvalue_fields' do
     specify { expect(subject.docvalue_fields(:foo).render[:body]).to include(docvalue_fields: ['foo']) }
     specify do


### PR DESCRIPTION
Add the [`collapse`](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html) option to the request.

```ruby
PlacesIndex.collapse(field: :name)
# => <PlacesIndex::Query {..., :body=>{:collapse=>{"field"=>:name}}}>
```
