### PR TITLE
Fix incorrect pagination in journaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs Fixed
 
 * [#842](https://github.com/toptal/chewy/issues/842): Fix `ignore_blank` handling. ([@rabotyaga][])
+* [#848](https://github.com/toptal/chewy/issues/848): Fix invalid journal pagination. ([@konalegi][])
 
 ## 7.2.5 (2022-03-04)
 
@@ -19,7 +20,7 @@
  * [#827](https://github.com/toptal/chewy/pull/827): Add `:lazy_sidekiq` strategy, that defers not only importing but also `update_index` callback evaluation for created and updated objects. ([@sl4vr][])
  * [#827](https://github.com/toptal/chewy/pull/827): Add `:atomic_no_refresh` strategy. Like `:atomic`, but `refresh=false` parameter is set. ([@barthez][])
  * [#827](https://github.com/toptal/chewy/pull/827): Add `:no_refresh` chain call to `update_index` matcher to ensure import was called with `refresh=false`. ([@barthez][])
- 
+
 ### Bugs Fixed
 
  * [#835](https://github.com/toptal/chewy/pull/835): Support keyword arguments in named scopes. ([@milk1000cc][])


### PR DESCRIPTION
This PR fixes two bugs: 
* Removes the retries principle, just because `Chewy::Stash::Journal.entries` methods as any es query have a limit of default 10 and in case you have more than 100 they are going to be ignored. Instead, pagination is based on the `total_count` will scan through all entires in the journal.
* Another bug is a result of the assumption that entries in the query are sorted by `created_at`, but in reality, it's not.
As an example imagine the following entries in the journal 

```
1. Entry (id: 1, created_at: '12:01:00')
2. Entry (id: 3, created_at: '12:04:00')
3. Entry (id: 2, created_at: '12:03:00')
4. Entry (id: 4, created_at: '12:05:00')
```

and the current algorithm step by step 
1. fetch 2 items older than `12:00:00`, as a result, entries with ids  1, 3 will be fetched ([src](https://github.com/toptal/chewy/blob/master/lib/chewy/journal.rb#L26))
2. calculate the latest in the batch ([src](https://github.com/toptal/chewy/blob/master/lib/chewy/journal.rb#L34)), latest created_at will be `12:04:00`
3. fetch 2 items older than`12:04:00`, as a result, we are going have entry with `id: 4` only 
4. Entry with 2 will be lost 

This bug fix is simple, fetch all entries ordered by `created_at`

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
