### PR TITLE
Fix return value of subscribed_task_stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* [#856](https://github.com/toptal/chewy/pull/856): Fix return value of subscribed_task_stats used in rake tasks. ([@fabiormoura][])
+
 ## 7.2.7 (2022-11-15)
 
 ### New Features

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -270,6 +270,7 @@ module Chewy
         ActiveSupport::Notifications.subscribed(JOURNAL_CALLBACK.curry[output], 'apply_journal.chewy') do
           ActiveSupport::Notifications.subscribed(IMPORT_CALLBACK.curry[output], 'import_objects.chewy', &block)
         end
+      ensure
         output.puts "Total: #{human_duration(Time.now - start)}"
       end
 

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -570,4 +570,11 @@ Total: \\d+s\\Z
       end
     end
   end
+
+  describe '.subscribed_task_stats' do
+    specify do
+      block_output = described_class.subscribed_task_stats(StringIO.new) { 'expected output' }
+      expect(block_output).to eq('expected output')
+    end
+  end
 end


### PR DESCRIPTION
The method `subscribed_task_stats` wraps almost all methods in RakeHelper but it has a bug.

For instance, the `upgrade` method in the same module is supposed to return a list of changed indexes in https://github.com/toptal/chewy/blob/7d567542c7685cf44a52050b8d16e61c373cd186/lib/chewy/rake_helper.rb#L65-L85

However, the wrapping method isn't returning to the caller the value of `changed_indexes`. Instead, it returns the result of the method `output.puts` which is `nil`.

I'm simply moving `output.puts` to be called within `ensure` so the output of the method correctly returns the result of:

```rb
ActiveSupport::Notifications.subscribed(Chewy::RakeHelper::JOURNAL_CALLBACK.curry[output], "apply_journal.chewy") do
    ActiveSupport::Notifications.subscribed(Chewy::RakeHelper::IMPORT_CALLBACK.curry[output], "import_objects.chewy", &block)
end
```
that would resolve to the correct value in the end when `&block` is evaluated.


-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
