### PR TITLE
Optimize CI execution on PR and Push, to not run them twice

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [
+      synchronize, # PR was updated
+      opened # PR was open
+    ]
 
 jobs:
   ruby-2:


### PR DESCRIPTION
Recently have noticed that we run CI checks twice since triggers are configured incorrectly. 
<img width="555" alt="Screen Shot 2022-09-19 at 17 57 04" src="https://user-images.githubusercontent.com/1387057/191048191-b7236dc9-f2dc-4177-93b9-55b17bae398c.png">

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* (n/a) Added tests.
* (n/a) Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
