### PR TITLE
Fix in mock_elasticsearch_response_sources

### DIFF
--- a/lib/chewy/minitest/helpers.rb
+++ b/lib/chewy/minitest/helpers.rb
@@ -97,7 +97,7 @@ module Chewy
               {
                 '_index' => index.index_name,
                 '_type' => '_doc',
-                '_id' => (i + 1).to_s,
+                '_id' => hit[:id] || (i + 1).to_s,
                 '_score' => 3.14,
                 '_source' => hit
               }

--- a/spec/chewy/minitest/helpers_spec.rb
+++ b/spec/chewy/minitest/helpers_spec.rb
@@ -32,14 +32,14 @@ describe :minitest_helper do
         {
           '_index' => 'dummies',
           '_type' => '_doc',
-          '_id' => '1',
+          '_id' => '2',
           '_score' => 3.14,
           '_source' => source
         }
       ]
     end
 
-    let(:source) { {'name' => 'some_name'} }
+    let(:source) { {'name' => 'some_name', id: '2'} }
     let(:sources) { [source] }
 
     context 'mocks by raw response' do


### PR DESCRIPTION
The "_id" is currently the incrementing id from the `each_with_index` loop. However, this id is eventually used in the [all_scope_where_ids_in](https://github.com/toptal/chewy/blob/48001e76c1c381c78811c9a74e5d07f5506a492a/lib/chewy/index/adapter/orm.rb#L151) method, where it subsequently fails.

If you add `id: ...` to your hits that are passed as a parameter in the `mock_elasticsearch_response_sources` method, this helper method now works.

Fixes https://github.com/toptal/chewy/issues/862

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
