### PR TITLE
Fix `chewy:journal:clean` task for ruby 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* [#874](https://github.com/toptal/chewy/pull/874): Fix `chewy:journal:clean` task for ruby 3.x. ([@muk-ai](https://github.com/muk-ai))
+
 ## 7.3.0 (2023-04-03)
 
 ### New Features

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -96,7 +96,7 @@ namespace :chewy do
     task clean: :environment do |_task, args|
       delete_options = Chewy::RakeHelper.delete_by_query_options_from_env(ENV)
       Chewy::RakeHelper.journal_clean(
-        [
+        **[
           parse_journal_args(args.extras),
           {delete_by_query_options: delete_options}
         ].reduce({}, :merge)

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -464,7 +464,7 @@ Total: \\d+s\\Z
         Rake::DefaultLoader.new.load('lib/tasks/chewy.rake')
         Rake::Task.define_task(:environment)
       end
-      it "does not raise error" do
+      it 'does not raise error' do
         expect { task.invoke }.to_not raise_error
       end
     end

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rake'
 
 describe Chewy::RakeHelper, :orm do
   before { Chewy.massacre }
@@ -455,6 +456,17 @@ Total: \\d+s\\Z
 \\ATask to cleanup the journal has been created, [^\\n]*
 Total: \\d+s\\Z
       OUTPUT
+    end
+
+    context 'execute "chewy:journal:clean" rake task' do
+      subject(:task) { Rake.application['chewy:journal:clean'] }
+      before do
+        Rake::DefaultLoader.new.load('lib/tasks/chewy.rake')
+        Rake::Task.define_task(:environment)
+      end
+      it "does not raise error" do
+        expect { task.invoke }.to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
This task seems to fails in ruby 3.x because keyword arguments are not expanded.

```
$ bundle exec rails "chewy:journal:clean"
rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 0)

Tasks: TOP => chewy:journal:clean
(See full trace by running task with --trace)
```

ruby: 3.0.4
chewy: 7.2.7

I added double splat operator.
