### PR TITLE
Replace bypass strategy description with one that better describes behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,9 @@ It is convenient for use in e.g. the Rails console with non-block notation:
 
 #### `:bypass`
 
-The bypass strategy simply silences index updates.
+When the bypass strategy is active the index will not be automatically updated on object save.
+
+For example, on `City.first.save!` the cities index would not be updated.
 
 #### Nesting
 


### PR DESCRIPTION
The current description of the bypass strategy uses the phrase "simply silences index updates" to describe the bypass strategy. I think this is misleading as doing something silently doesn't mean that a process does not happen but rather that there is no output. If I select a process to happen silently, I would expect a normal behaviour but without anything being logged or output to the console.

I believe that the bypass strategy does more than simply suppress output. Instead it bypasses the index update on model save.