### PR TITLE
Skip journal creation on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* [#888](https://github.com/toptal/chewy/pull/888/files): Skip journal creation on import ([@konalegi](https://github.com/konalegi))
+
 ### Changes
 
 ### Bugs Fixed

--- a/lib/chewy/index/import/routine.rb
+++ b/lib/chewy/index/import/routine.rb
@@ -64,7 +64,7 @@ module Chewy
         # Creates the journal index and the corresponding index if necessary.
         # @return [Object] whatever
         def create_indexes!
-          Chewy::Stash::Journal.create if @options[:journal]
+          Chewy::Stash::Journal.create if @options[:journal] && !Chewy.configuration[:skip_journal_creation_on_import]
           return if Chewy.configuration[:skip_index_creation_on_import]
 
           @index.create!(**@bulk_options.slice(:suffix)) unless @index.exists?

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -197,6 +197,19 @@ module Chewy
         end
       end
 
+      # Creates journal index.
+      #
+      # @example
+      #   Chewy::RakeHelper.journal_create # creates journal
+      #
+      # @param output [IO] output io for logging
+      # @return Chewy::Index Returns instance of chewy index
+      def journal_create(output: $stdout)
+        subscribed_task_stats(output) do
+          Chewy::Stash::Journal.create!
+        end
+      end
+
       # Eager loads and returns all the indexes defined in the application
       # except Chewy::Stash::Specification and Chewy::Stash::Journal.
       #

--- a/lib/tasks/chewy.rake
+++ b/lib/tasks/chewy.rake
@@ -87,6 +87,11 @@ namespace :chewy do
   end
 
   namespace :journal do
+    desc 'Create manually journal, useful when `skip_journal_creation_on_import` is used'
+    task create: :environment do |_task, _args|
+      Chewy::RakeHelper.journal_create
+    end
+
     desc 'Applies changes that were done after the specified time for the specified indexes/types or all of them'
     task apply: :environment do |_task, args|
       Chewy::RakeHelper.journal_apply(**parse_journal_args(args.extras))

--- a/spec/chewy/index/import_spec.rb
+++ b/spec/chewy/index/import_spec.rb
@@ -60,6 +60,19 @@ describe Chewy::Index::Import do
         CitiesIndex.import(dummy_city)
       end
     end
+
+    context 'skip journal creation on import' do
+      before do
+        Chewy::Stash::Journal.create!
+        Chewy.config.settings[:skip_journal_creation_on_import] = true
+      end
+      after { Chewy.config.settings[:skip_journal_creation_on_import] = nil }
+
+      specify do
+        expect(Chewy::Stash::Journal).not_to receive(:create!)
+        CitiesIndex.import(dummy_city, journal: true)
+      end
+    end
   end
 
   shared_examples 'importing' do

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -470,6 +470,17 @@ Total: \\d+s\\Z
     end
   end
 
+  describe '.journal_create' do
+    specify do
+      output = StringIO.new
+      described_class.journal_create(output: output)
+      expect(Chewy::Stash::Journal.exists?).to be_truthy
+      expect(output.string).to match(Regexp.new(<<-OUTPUT, Regexp::MULTILINE))
+Total: \\d+s\\Z
+      OUTPUT
+    end
+  end
+
   describe '.reindex' do
     before do
       journal


### PR DESCRIPTION
Adds option to disable journal creation on import. Since it's executed on each import that might save a lot of bandwidth, for our app it's around 20% of all requests. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
