### PR TITLE
Add helper to cleanup delayed sidekiq timechunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* [#894](https://github.com/toptal/chewy/pull/894): Way of cleaning redis from artifacts left by `delayed_sidekiq` strategy which could potentially cause flaky tests. ([@Drowze](https://github.com/Drowze))
+
 ### Changes
 
 ### Bugs Fixed

--- a/README.md
+++ b/README.md
@@ -848,6 +848,12 @@ Explicit call of the reindex using `:delayed_sidekiq` strategy with `:update_fie
 CitiesIndex.import([1, 2, 3], update_fields: [:name], strategy: :delayed_sidekiq)
 ```
 
+While running tests with delayed_sidekiq strategy and Sidekiq is using a real redis instance that is NOT cleaned up in between tests (via e.g. `Sidekiq.redis(&:flushdb)`), you'll want to cleanup some redis keys in between tests to avoid state leaking and flaky tests. Chewy provides a convenience method for that:
+```ruby
+# it might be a good idea to also add to your testing setup, e.g.: a rspec `before` hook
+Chewy::Strategy::DelayedSidekiq.clear_timechunks!
+```
+
 #### `:active_job`
 
 This does the same thing as `:atomic`, but using ActiveJob. This will inherit the ActiveJob configuration settings including the `active_job.queue_adapter` setting for the environment. Patch `Chewy::Strategy::ActiveJob::Worker` for index updates improving.

--- a/lib/chewy/strategy/delayed_sidekiq.rb
+++ b/lib/chewy/strategy/delayed_sidekiq.rb
@@ -5,6 +5,19 @@ module Chewy
     class DelayedSidekiq < Sidekiq
       require_relative 'delayed_sidekiq/scheduler'
 
+      # cleanup the redis sets used internally. Useful mainly in tests to avoid
+      # leak and potential flaky tests.
+      def self.clear_timechunks!
+        ::Sidekiq.redis do |redis|
+          timechunk_sets = redis.smembers(Chewy::Strategy::DelayedSidekiq::Scheduler::ALL_SETS_KEY)
+          break if timechunk_sets.empty?
+
+          redis.pipelined do |pipeline|
+            timechunk_sets.each { |set| pipeline.del(set) }
+          end
+        end
+      end
+
       def leave
         @stash.each do |type, ids|
           next if ids.empty?

--- a/lib/chewy/strategy/delayed_sidekiq/scheduler.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/scheduler.rb
@@ -18,6 +18,7 @@ module Chewy
         DEFAULT_MARGIN = 2
         DEFAULT_QUEUE = 'chewy'
         KEY_PREFIX = 'chewy:delayed_sidekiq'
+        ALL_SETS_KEY = "#{KEY_PREFIX}:all_sets".freeze
         FALLBACK_FIELDS = 'all'
         FIELDS_IDS_SEPARATOR = ';'
         IDS_SEPARATOR = ','
@@ -68,8 +69,10 @@ module Chewy
           ::Sidekiq.redis do |redis|
             # warning: Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead
             if redis.respond_to?(:sadd?)
+              redis.sadd?(ALL_SETS_KEY, timechunks_key)
               redis.sadd?(timechunk_key, serialize_data)
             else
+              redis.sadd(ALL_SETS_KEY, timechunks_key)
               redis.sadd(timechunk_key, serialize_data)
             end
 


### PR DESCRIPTION
# For context:
https://github.com/toptal/chewy/pull/869 added the `delayed_sidekiq` strategy, which by design will only create a sidekiq worker to update an index every N seconds (10 seconds by default).
The implementation details for that involves redis sorted sets: it creates a sorted set for each index that uses the strategy and adds a new member to it everytime we call reindex (with the weight being calculated from the current timestamp, generating a unique number every N seconds).

# The problem:
Since we're writing directly to Redis, if we use this strategy in tests we're subject to state leaking and creating flaky tests. For example:
* test A runs some code that calls `MyClass.import!(1, strategy: :delayed_sidekiq)` and not flush the Sidekiq workers or the redis database
* in less than 10 seconds, test B runs some code that calls `MyClass.import!(1, strategy: :delayed_sidekiq)`, flushes Sidekiq workers and expects the index to be updated.  

On the above scenario, test B will **fail** as no worker will be enqueued since `import!` was called within 10 seconds in between the tests (also note that Sidekiq runs in memory by default when running tests, so workers enqueued by test A are not present in test B).

# The fix:
This PR adds a way to workaround the issue by cleaning up the saved timechunks. It can easily be added to e.g. rspec hooks via:
```ruby
RSpec.configure do |config|
  config.after { Chewy::Strategy::DelayedSidekiq.clear_timechunks! }
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
