### PR TITLE
[Fix #903] Fix deprecation warning in LogSubscriber in Rails 7.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '3.0', '3.1', '3.2' ]
-        gemfile: [ rails.6.1.activerecord, rails.7.0.activerecord ]
+        gemfile: [ rails.6.1.activerecord, rails.7.0.activerecord, rails.7.1.activerecord ]
     name: ${{ matrix.ruby }}-${{ matrix.gemfile }}
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* [#907](https://github.com/toptal/chewy/pull/907): Fix deprecation warning in LogSubscriber for Rails 7.1 ([@alejandroperea](https://github.com/alejandroperea))
+
 ### Changes
 
 ### Bugs Fixed

--- a/gemfiles/rails.7.1.activerecord.gemfile
+++ b/gemfiles/rails.7.1.activerecord.gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+gem 'activejob', '~> 7.1.0'
+gem 'activerecord', '~> 7.1.0'
+gem 'activesupport', '~> 7.1.0'
+gem 'kaminari-core', '~> 1.1.0', require: false
+gem 'parallel', require: false
+gem 'rspec_junit_formatter', '~> 0.4.1'
+gem 'sidekiq', require: false
+
+gem 'rexml' if RUBY_VERSION >= '3.0.0'
+
+gemspec path: '../'

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/version'
 require 'active_support/concern'
 require 'active_support/deprecation'

--- a/lib/chewy/log_subscriber.rb
+++ b/lib/chewy/log_subscriber.rb
@@ -24,7 +24,11 @@ module Chewy
 
       subject = payload[:type].presence || payload[:index]
       action = "#{subject} #{action} (#{event.duration.round(1)}ms)"
-      action = color(action, GREEN, true)
+      action = if ActiveSupport.version >= Gem::Version.new('7.1')
+        color(action, GREEN, bold: true)
+      else
+        color(action, GREEN, true)
+      end
 
       debug("  #{action} #{description}")
     end


### PR DESCRIPTION
Fixes https://github.com/toptal/chewy/issues/903

`color` method was changed in Rails 7.1, introducing a `mode_options` hash instead of a position parameter just for bold option.

This PR checks the ActiveSupport version and calls `color` method with the proper parameters.

Also, I've added the configuration for executing the CI for Rails 7.1 version

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
