### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.7]
         gemfile: [rails.5.2.activerecord, rails.6.0.activerecord, rails.6.1.activerecord]
     name: ${{ matrix.ruby }}-${{ matrix.gemfile }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,3 @@ gem 'redcarpet'
 gem 'yard'
 
 gem 'rexml' if RUBY_VERSION >= '3.0.0'
-gem 'ruby2_keywords' if RUBY_VERSION < '2.7'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Or install it yourself as:
 
 ### Ruby
 
-Chewy is compatible with MRI 2.6-3.0¹.
+Chewy is compatible with MRI 2.7-3.0¹.
 
 > ¹ Ruby 3 is only supported with Rails 6.1
 

--- a/lib/chewy/fields/root.rb
+++ b/lib/chewy/fields/root.rb
@@ -27,7 +27,7 @@ module Chewy
         mappings[name]
       end
 
-      ruby2_keywords def dynamic_template(*args)
+      def dynamic_template(*args)
         options = args.extract_options!.deep_symbolize_keys
         if args.first
           template_name = :"template_#{dynamic_templates.count.next}"

--- a/lib/chewy/index/adapter/object.rb
+++ b/lib/chewy/index/adapter/object.rb
@@ -85,7 +85,7 @@ module Chewy
         # @param args [Array<#to_json>]
         # @option options [Integer] :batch_size import processing batch size
         # @return [true, false]
-        ruby2_keywords def import(*args, &block)
+        def import(*args, &block)
           collection, options = import_args(*args)
           import_objects(collection, options, &block)
         end
@@ -113,7 +113,7 @@ module Chewy
         #   end
         #
         # @see Chewy::Index::Adapter::Base#import_fields
-        ruby2_keywords def import_fields(*args, &block)
+        def import_fields(*args, &block)
           return enum_for(:import_fields, *args) unless block_given?
 
           options = args.extract_options!
@@ -139,7 +139,7 @@ module Chewy
         # For the Object adapter returns the objects themselves in batches.
         #
         # @see Chewy::Index::Adapter::Base#import_references
-        ruby2_keywords def import_references(*args, &block)
+        def import_references(*args, &block)
           return enum_for(:import_references, *args) unless block_given?
 
           collection, options = import_args(*args)

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -72,7 +72,7 @@ module Chewy
         #   # or
         #   UsersIndex.import users.map(&:id) # user ids will be deleted from index
         #
-        ruby2_keywords def import(*args, &block)
+        def import(*args, &block)
           collection, options = import_args(*args)
 
           if !collection.is_a?(relation_class) || options[:direct_import]
@@ -82,7 +82,7 @@ module Chewy
           end
         end
 
-        ruby2_keywords def import_fields(*args, &block)
+        def import_fields(*args, &block)
           return enum_for(:import_fields, *args) unless block_given?
 
           collection, options = import_args(*args)

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -72,7 +72,7 @@ module Chewy
         # @option options [true, false] update_failover enables full objects reimport in cases of partial update errors, `true` by default
         # @option options [true, Integer, Hash] parallel enables parallel import processing with the Parallel gem, accepts the number of workers or any Parallel gem acceptable options
         # @return [true, false] false in case of errors
-        ruby2_keywords def import(*args)
+        def import(*args)
           intercept_import_using_strategy(*args).blank?
         end
 
@@ -83,7 +83,7 @@ module Chewy
         # in case of any import errors.
         #
         # @raise [Chewy::ImportFailed] in case of errors
-        ruby2_keywords def import!(*args)
+        def import!(*args)
           errors = intercept_import_using_strategy(*args)
 
           raise Chewy::ImportFailed.new(self, errors) if errors.present?

--- a/lib/chewy/index/observe/active_record_methods.rb
+++ b/lib/chewy/index/observe/active_record_methods.rb
@@ -71,7 +71,7 @@ module Chewy
             end
           end
 
-          ruby2_keywords def update_index(type_name, *args, &block)
+          def update_index(type_name, *args, &block)
             callback_options = Observe.extract_callback_options!(args)
             update_proc = Observe.update_proc(type_name, *args, &block)
             callback = Chewy::Index::Observe::Callback.new(update_proc, callback_options)

--- a/lib/chewy/search.rb
+++ b/lib/chewy/search.rb
@@ -56,7 +56,7 @@ module Chewy
       #
       # @example
       #   PlacesIndex.query(match: {name: 'Moscow'})
-      ruby2_keywords def method_missing(name, *args, &block)
+      def method_missing(name, *args, &block)
         if search_class::DELEGATED_METHODS.include?(name)
           all.send(name, *args, &block)
         else
@@ -87,7 +87,7 @@ module Chewy
             define_method method do |*args, &block|
               scoping { source.public_send(method, *args, &block) }
             end
-            ruby2_keywords method
+            method
           end
         end
       end


### PR DESCRIPTION
Ruby 2.6 reached its EOL almost 2 years ago.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
