### PR TITLE
Raise error in #scroll_batches when search backend returns a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,6 +1275,14 @@ If you use `DatabaseCleaner` in your tests with [the `transaction` strategy](htt
 Chewy.use_after_commit_callbacks = !Rails.env.test?
 ```
 
+## Running specs
+
+Make sure you're running a local Elasticsearch instance.
+
+```
+ES_PORT=9200 bundle exec rspec
+```
+
 ## Contributing
 
 1. Fork it (http://github.com/toptal/chewy/fork)

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -34,6 +34,9 @@ module Chewy
         scroll_id = nil
 
         loop do
+          failures = result.dig('_shards', 'failures')
+          raise Chewy::Error, failures if failures.present?
+
           hits = result.fetch('hits', {}).fetch('hits', [])
           fetched += hits.size
           hits = hits.first(last_batch_size) if last_batch_size != 0 && fetched >= total

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -33,6 +33,56 @@ describe Chewy::Search::Scrolling, :orm do
     let(:countries) { Array.new(3) { |i| Country.create!(rating: i + 2, name: "country #{i}") } }
 
     describe '#scroll_batches' do
+      describe 'with search backend returning failures' do
+        before do
+          expect(Chewy.client).to receive(:scroll).once.and_return(
+            'hits' => {
+              'total' => {
+                'value' => 5
+              },
+              'hits' => []
+            },
+            '_shards' => {
+              'total' => 5,
+              'successful' => 2,
+              'skipped' => 0,
+              'failed' => 3,
+              'failures' => [
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462229]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34462228]'
+                  }
+                },
+                {
+                  'shard' => -1,
+                  'index' => nil,
+                  'reason' => {
+                    'type' => 'search_context_missing_exception',
+                    'reason' => 'No search context found for id [34888662]'
+                  }
+                }
+              ]
+            },
+            '_scroll_id' => 'scroll_id'
+          )
+        end
+
+        specify do
+          expect { request.scroll_batches(batch_size: 2) {} }.to raise_error(Chewy::Error)
+        end
+      end
+
       context do
         before { expect(Chewy.client).to receive(:scroll).twice.and_call_original }
         specify do


### PR DESCRIPTION
We are running into a bug in production when performing `chewy:sync`. 

Our search backend is intermittently returning a `200` response without _hits_ and containing a backend failure, see example response:

```
{
  "_scroll_id": "<scroll_id>",
  "took": 1,
  "timed_out": false,
  "terminated_early": false,
  "_shards": {
    "total": 5,
    "successful": 2,
    "skipped": 0,
    "failed": 3,
    "failures": [
      {
        "shard": -1,
        "index": null,
        "reason": {
          "type": "search_context_missing_exception",
          "reason": "No search context found for id [34462229]"
        }
      },
      {
        "shard": -1,
        "index": null,
        "reason": {
          "type": "search_context_missing_exception",
          "reason": "No search context found for id [34462228]"
        }
      },
      {
        "shard": -1,
        "index": null,
        "reason": {
          "type": "search_context_missing_exception",
          "reason": "No search context found for id [34888662]"
        }
      }
    ]
  },
  "hits": {
    "total": {
      "value": 720402,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": []
  }
}
```

[scroll_batches](https://github.com/tomdev/chewy/blob/master/lib/chewy/search/scrolling.rb#L27C11-L27C25) currently is not taking these _failures_ into account. Because there are no hits returned, the logic of `fetched >= total` will never be reached, causing the loop to never break. 

Because of this we've experienced `chewy:sync` running for days instead of an hour. (Yes, we now have proper monitoring in place...)

This PR will raise a `Chewy::Error` when the search backend is returning failures. 



-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
