### PR TITLE
Make default index scope cleanup behavior configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* [#925](https://github.com/toptal/chewy/pull/925): Add configuration option for default scope cleanup behavior. ([@barthez][])
+
 ### Changes
 
 ### Bugs Fixed

--- a/README.md
+++ b/README.md
@@ -1298,6 +1298,24 @@ While using the `before_es_request_filter`, please consider the following:
 * The return value of the proc is disregarded. This filter is intended for inspection or modification of the query rather than generating a response.
 * Any exception raised inside the callback will propagate upward and halt the execution of the query. It is essential to handle potential errors adequately to ensure the stability of your search functionality.
 
+### Import scope clean-up behavior
+
+Whenever you set the `import_scope` for the index, in the case of ActiveRecord,
+options for order, offset and limit will be removed. You can set the behavior of
+chewy, before the clean-up itself.
+
+The default behavior is a warning sent to the Chewy logger (`:warn`). Another more
+restrictive option is raising an exception (`:raise`). Both options have a
+negative impact on performance since verifying whether the code uses any of
+these options requires building AREL query.
+
+To avoid the loading time impact, you can ignore the check (`:ignore`) before
+the clean-up.
+
+```
+Chewy.import_scope_cleanup_behavior = :ignore
+```
+
 ## Contributing
 
 1. Fork it (http://github.com/toptal/chewy/fork)

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -40,7 +40,10 @@ module Chewy
                   # Default field type for any field in any Chewy type. Defaults to 'text'.
                   :default_field_type,
                   # Callback called on each search request to be done into ES
-                  :before_es_request_filter
+                  :before_es_request_filter,
+                  # Behavior when import scope for index includes order, offset or limit.
+                  # Can be :ignore, :warn, :raise. Defaults to :warn
+                  :import_scope_cleanup_behavior
 
     attr_reader :transport_logger, :transport_tracer,
                 # Chewy search request DSL base class, used by every index.
@@ -62,6 +65,7 @@ module Chewy
       @indices_path = 'app/chewy'
       @default_root_options = {}
       @default_field_type = 'text'.freeze
+      @import_scope_cleanup_behavior = :warn
       @search_class = build_search_class(Chewy::Search::Request)
     end
 

--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -36,4 +36,7 @@ module Chewy
       super("`#{join_field_type}` set for the join field `#{join_field_name}` is not on the :relations list (#{relations})")
     end
   end
+
+  class ImportScopeCleanupError < Error
+  end
 end

--- a/lib/chewy/index/adapter/active_record.rb
+++ b/lib/chewy/index/adapter/active_record.rb
@@ -13,9 +13,19 @@ module Chewy
       private
 
         def cleanup_default_scope!
-          if Chewy.logger && (@default_scope.arel.orders.present? ||
+          behavior = Chewy.config.import_scope_cleanup_behavior
+
+          if behavior != :ignore && (@default_scope.arel.orders.present? ||
              @default_scope.arel.limit.present? || @default_scope.arel.offset.present?)
-            Chewy.logger.warn('Default type scope order, limit and offset are ignored and will be nullified')
+            if behavior == :warn && Chewy.logger
+              gem_dir = File.realpath('../..', __dir__)
+              source = caller.grep_v(Regexp.new(gem_dir)).first
+              Chewy.logger.warn(
+                "Default type scope order, limit and offset are ignored and will be nullified (called from: #{source})"
+              )
+            elsif behavior == :raise
+              raise ImportScopeCleanupError, "Default type scope order, limit and offset are ignored and will be nullified"
+            end
           end
 
           @default_scope = @default_scope.reorder(nil).limit(nil).offset(nil)

--- a/lib/chewy/index/adapter/active_record.rb
+++ b/lib/chewy/index/adapter/active_record.rb
@@ -24,7 +24,7 @@ module Chewy
                 "Default type scope order, limit and offset are ignored and will be nullified (called from: #{source})"
               )
             elsif behavior == :raise
-              raise ImportScopeCleanupError, "Default type scope order, limit and offset are ignored and will be nullified"
+              raise ImportScopeCleanupError, 'Default type scope order, limit and offset are ignored and will be nullified'
             end
           end
 


### PR DESCRIPTION
Instead of warning, you can completely ignore cases when the scope include order/offset/limit or you can raise an exception instead.

This change is actually a performance improvment. Avoiding `arel` calls to identify it default scope has order/offset/limit is time consuming and we don't need to verify it every time we boot. 

Additional option of raising an exception might be useful for tests to prevent defining scopes with ordering or pagination.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
