### PR TITLE
Relax allowed `elasticsearch` dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+* [#933](https://github.com/toptal/chewy/pull/933): Relax allowed `elasticsearch` dependency versions. ([@mjankowski][])
+
 ### Bugs Fixed
 
 ## 7.5.1 (2024-01-30)

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 5.2' # Remove with major version bump, 8.x
-  spec.add_dependency 'elasticsearch', '>= 7.12.0', '< 7.14.0'
+  spec.add_dependency 'elasticsearch', '>= 7.12.0', '< 8'
   spec.add_dependency 'elasticsearch-dsl'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 5.2' # Remove with major version bump, 8.x
-  spec.add_dependency 'elasticsearch', '>= 7.12.0', '< 8'
+  spec.add_dependency 'elasticsearch', '>= 7.14.0', '< 8'
   spec.add_dependency 'elasticsearch-dsl'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -70,12 +70,12 @@ module Chewy
     end
 
     def transport_logger=(logger)
-      Chewy.client.transport.logger = logger
+      Chewy.client.transport.transport.logger = logger
       @transport_logger = logger
     end
 
     def transport_tracer=(tracer)
-      Chewy.client.transport.tracer = tracer
+      Chewy.client.transport.transport.tracer = tracer
       @transport_tracer = tracer
     end
 

--- a/spec/chewy/config_spec.rb
+++ b/spec/chewy/config_spec.rb
@@ -22,7 +22,7 @@ describe Chewy::Config do
 
     specify do
       expect { subject.transport_logger = logger }
-        .to change { Chewy.client.transport.logger }.to(logger)
+        .to change { Chewy.client.transport.transport.logger }.to(logger)
     end
     specify do
       expect { subject.transport_logger = logger }
@@ -40,7 +40,7 @@ describe Chewy::Config do
 
     specify do
       expect { subject.transport_tracer = tracer }
-        .to change { Chewy.client.transport.tracer }.to(tracer)
+        .to change { Chewy.client.transport.transport.tracer }.to(tracer)
     end
     specify do
       expect { subject.transport_tracer = tracer }


### PR DESCRIPTION
Saw the comment here - https://github.com/toptal/chewy/issues/847#issuecomment-1824503608 - which notes that newer 7.x versions of elasticsearch gem allow either Faraday 1.x or 2.x.

This change might be a good stopgap to include in a Chewy 7.x release while work on ES8 support (in Chewy 8) continues on that PR.