### PR TITLE
Fix intermittent time-based failure in delayed sidekiq spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+* [#947](https://github.com/toptal/chewy/pull/947): Fix intermittent time-based failure in delayed sidekiq spec. ([@mjankowski][])
+
 ## 7.5.1 (2024-01-30)
 
 ### New Features

--- a/spec/chewy/strategy/delayed_sidekiq_spec.rb
+++ b/spec/chewy/strategy/delayed_sidekiq_spec.rb
@@ -47,7 +47,7 @@ if defined?(Sidekiq)
           expect(Sidekiq::Client).to receive(:push).with(
             hash_including(
               'queue' => 'chewy',
-              'at' => (Time.current.to_i.ceil(-1) + 2.seconds).to_i,
+              'at' => expected_at_time.to_i,
               'class' => Chewy::Strategy::DelayedSidekiq::Worker,
               'args' => ['CitiesIndex', an_instance_of(Integer)]
             )
@@ -61,6 +61,11 @@ if defined?(Sidekiq)
               .and_reindex(city, other_city).only
           end
         end
+      end
+
+      def expected_at_time
+        target = described_class::Scheduler::DEFAULT_LATENCY.seconds.from_now.to_i
+        target - (target % described_class::Scheduler::DEFAULT_LATENCY) + described_class::Scheduler::DEFAULT_MARGIN.seconds
       end
     end
 


### PR DESCRIPTION
This example was previously failing when it was run at exactly an "even" 10 second increment time. For example, it would fail at "12:00:10", but pass at "12:00:09" and "12:00:11". This leads to intermittent failures on CI (presumably around ~10% of runs).

Updated to use a helper method in the spec which more closely mirrors the scheduler code.

I noticed this during the CI runs from the previous PR ... and was able to verify this pattern by setting a specific time target for the `Timecop.freeze` line, which confirmed the pattern of fail/pass.