### PR TITLE
Add ES inner_hits support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* [#950](https://github.com/toptal/chewy/issues/950): Adds supports for inner_hits in the search request. ([@JonathanFrias][])
+
 ### Changes
 
 ### Bugs Fixed

--- a/lib/chewy/search/parameters/inner_hits.rb
+++ b/lib/chewy/search/parameters/inner_hits.rb
@@ -1,0 +1,16 @@
+require 'chewy/search/parameters/storage'
+
+module Chewy
+  module Search
+    class Parameters
+      # Just a standard hash storage. Nothing to see here.
+      #
+      # @see Chewy::Search::Parameters::HashStorage
+      # @see Chewy::Search::Request#inner_hits
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html
+      class InnerHits < Storage
+        include HashStorage
+      end
+    end
+  end
+end

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -22,7 +22,7 @@ module Chewy
       DELEGATED_METHODS = %i[
         query filter post_filter knn order reorder docvalue_fields
         track_scores track_total_hits request_cache explain version profile
-        search_type preference limit offset terminate_after
+        search_type preference limit offset terminate_after inner_hits
         timeout min_score source stored_fields search_after
         load script_fields suggest aggs aggregations collapse none
         indices_boost rescore highlight total total_count
@@ -41,7 +41,7 @@ module Chewy
       EXTRA_STORAGES = %i[aggs suggest].freeze
       # An array of storage names that are changing the returned hist collection in any way.
       WHERE_STORAGES = %i[
-        query filter post_filter knn none min_score rescore indices_boost collapse
+        query filter post_filter inner_hits knn none min_score rescore indices_boost collapse
       ].freeze
 
       delegate :hits, :wrappers, :objects, :records, :documents,
@@ -535,6 +535,20 @@ module Chewy
         define_method name do |value|
           modify(name) { replace!(value) }
         end
+      end
+
+      # @!method inner_hits(value)
+      #  Updates `inner_hits` request part
+      #
+      #  @example
+      #  PlacesIndex.inner_hits(attendees: {size: 5})
+      #  # => <PlacesIndex::Query {..., :body=>{:inner_hits=>{:attendees=>{:size=>5}}}}>
+      #  @see Chewy::Search::Parameters::InnerHits
+      #  @see https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html
+      #  @param value [Hash]
+      #  @return [Chewy::Search::Request]
+      def inner_hits(value)
+        modify(:inner_hits) { update!(value) }
       end
 
       # @!method source(*values)

--- a/spec/chewy/search/parameters/inner_hits_spec.rb
+++ b/spec/chewy/search/parameters/inner_hits_spec.rb
@@ -1,0 +1,5 @@
+require 'chewy/search/parameters/hash_storage_examples'
+
+describe Chewy::Search::Parameters::InnerHits do
+  it_behaves_like :hash_storage, :inner_hits
+end

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -314,7 +314,7 @@ describe Chewy::Search::Request do
     end
   end
 
-  %i[collapse knn].each do |name|
+  %i[collapse knn inner_hits].each do |name|
     describe "##{name}" do
       specify { expect(subject.send(name, foo: {bar: 42}).render[:body]).to include(name => {'foo' => {bar: 42}}) }
       specify do


### PR DESCRIPTION
Adds support for ElasticSearch's [inner hits](https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html) feature

```ruby
class A < Chewy::Index
end

A.inner_hits(foo: 'bar')
# => <A::Query {:index=>["a"], :body=>{:inner_hits=>{"foo"=>"bar"}}}>

```


Fixes #308, #950 

This work was derived from https://github.com/toptal/chewy/pull/890