### PR TITLE
Fix id conversion issue in delayed_sidekiq strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+* [#964](https://github.com/toptal/chewy/pull/964): Fix `delayed_sidekiq` worker to handle UUID primary keys correctly.
+
 ## 8.0.0-beta (2024-08-27)
 
 ### New Features

--- a/lib/chewy/strategy/delayed_sidekiq/worker.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/worker.rb
@@ -68,7 +68,7 @@ module Chewy
 
           fields = nil if fields.include?(Scheduler::FALLBACK_FIELDS)
 
-          [ids.map(&:to_i), fields]
+          [ids, fields]
         end
       end
     end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -6,17 +6,16 @@ if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
   ActiveRecord::Base.raise_in_transactional_callbacks = true
 end
 
-ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'countries'")
-ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'cities'")
-ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'locations'")
-ActiveRecord::Schema.define do
+def create_countries_table
   create_table :countries do |t|
     t.column :name, :string
     t.column :country_code, :string
     t.column :rating, :integer
     t.column :updated_at, :datetime
   end
+end
 
+def create_cities_table
   create_table :cities do |t|
     t.column :country_id, :integer
     t.column :name, :string
@@ -25,19 +24,43 @@ ActiveRecord::Schema.define do
     t.column :rating, :integer
     t.column :updated_at, :datetime
   end
+end
 
+def create_locations_table
   create_table :locations do |t|
     t.column :city_id, :integer
     t.column :lat, :string
     t.column :lon, :string
   end
+end
 
+def create_comments_table
   create_table :comments do |t|
     t.column :content, :string
     t.column :comment_type, :string
     t.column :commented_id, :integer
     t.column :updated_at, :datetime
   end
+end
+
+def create_users_table
+  create_table :users, id: false do |t|
+    t.column :id, :string
+    t.column :name, :string
+  end
+end
+
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'countries'")
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'cities'")
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'locations'")
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'comments'")
+ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS 'users'")
+ActiveRecord::Schema.define do
+  create_countries_table
+  create_cities_table
+  create_locations_table
+  create_comments_table
+  create_users_table
 end
 
 module ActiveRecordClassHelpers
@@ -72,6 +95,14 @@ module ActiveRecordClassHelpers
 
   def stub_model(name, superclass = nil, &block)
     stub_class(name, superclass || ActiveRecord::Base, &block)
+  end
+
+  def stub_uuid_model(name, superclass = nil, &block)
+    stub_class(name, superclass || ActiveRecord::Base) do
+      before_create { self.id = SecureRandom.uuid }
+      define_singleton_method(:primary_key, -> { 'id' })
+      class_eval(&block)
+    end
   end
 end
 


### PR DESCRIPTION
Ensure ids extracted from Redis remain strings, preventing UUID issues. Previously, ids were being converted to integers, causing problems with UUIDs in the `delayed_sidekiq` strategy.

This update also enhances the test suite:
- Existing tests are updated.
- A new test ensures the issue is resolved.

Due to SQLite's lack of UUID support, a `stub_uuid_model` method is added. This method stubs models with UUIDs, using `SecureRandom.uuid` for the primary key.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
