### PR TITLE
Update crutch.rb to allow crutch inter-dependency with efficiency

### DIFF
--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -25,6 +25,23 @@ module Chewy
           @index._crutches.key?(name) || super
         end
 
+        # This method triggers crutch executions whenever crutches are accessed
+        # This method is called from method_missing above, with crutch name as argument
+        # This allows the crutch to be invoked in two ways, depending upon the block passed.
+        # If crutch is defined with a block accepting only 1 argument, it is called with only @collection
+        # ```ruby
+        # :crutch my_independent_crutch do |entities|
+        #     <do stuff>
+        # end
+        # ```
+        # If crutch is defined with a block accepting 2 arguments, the second argument is all crutches so that we can invoke dependent crutches from here
+        # ```ruby
+        # :crutch my_dependent_crutch do |entities, crutches|
+        #     independent_entities = crutches.my_independent_crutch
+        #     <do stuff>
+        # end
+        # ```
+        # WARN: One thing to note here is that this method doesnt check for cycles. So its upto developer discretion to make sure they dont end up with a cycle here.
         def [](name)
           execution_block = @index._crutches[:"#{name}"]
           @crutches_instances[name] ||= if execution_block.arity == 2

--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -28,10 +28,10 @@ module Chewy
         def [](name)
           execution_block = @index._crutches[:"#{name}"]
           @crutches_instances[name] ||= if execution_block.arity == 2
-                                          execution_block.call(@collection, self)
-                                        else
-                                          execution_block.call(@collection)
-                                        end
+            execution_block.call(@collection, self)
+          else
+            execution_block.call(@collection)
+          end
         end
       end
 

--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -26,7 +26,12 @@ module Chewy
         end
 
         def [](name)
-          @crutches_instances[name] ||= @index._crutches[:"#{name}"].call(@collection)
+          execution_block = @index._crutches[:"#{name}"]
+          if execution_block.arity == 2
+            @crutches_instances[name] ||= execution_block.call(@collection, self)
+          else
+            @crutches_instances[name] ||= execution_block.call(@collection)
+          end
         end
       end
 

--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -27,11 +27,11 @@ module Chewy
 
         def [](name)
           execution_block = @index._crutches[:"#{name}"]
-          if execution_block.arity == 2
-            @crutches_instances[name] ||= execution_block.call(@collection, self)
-          else
-            @crutches_instances[name] ||= execution_block.call(@collection)
-          end
+          @crutches_instances[name] ||= if execution_block.arity == 2
+                                          execution_block.call(@collection, self)
+                                        else
+                                          execution_block.call(@collection)
+                                        end
         end
       end
 


### PR DESCRIPTION
Adds support for passing all crutches into a crutch definition, to be able to form a chain of crutches such that a field can depend and load only what it needs, instead of loading multiple objects at times, which might not all be required always.


Earlier:
```ruby
class MyIndex

    crutch :my_large_crutch do |models|
        model_rel1_ids = models.map { |m| m.rel1_id }
        rel1_objs = <Load objects of Rel1 from Mongo>
        rel2_ids = rel1_objs.map{ |r| r.rel2_id }
        rel2_objs  = <Load objects of Rel2 from Mongo>
        ..... Relations can go any nested levels
        data = {}
        data[:rel1_objs] = <hash_of rel1_objs>
        data[:rel2_objs] = <hash_of rel2_objs>
        data
    end

    field :field_belongs_to_rel1_obj # <also ends up loading rel2 objects in case of partial update>
    field :field_belongs_to_rel2_obj
end
```


Now:

```ruby
class MyIndex

    crutch :my_rel1_objs do |models|
         model_rel1_ids = models.map { |m| m.rel1_id }
        rel1_objs = <Load objects of Rel1 from Mongo>
        <hash of rel1_objs>
    end

    crutch :my_rel2_objs do |_, crutches|
         rel1_objs = crutches.my_rel1_objs
         rel2_ids = rel1_objs.map{ |r| r.rel2_id }
        rel2_objs  = <Load objects of Rel2 from Mongo>
        <hash of rel2_objs>
    end
    
    field :field_belongs_to_rel1_obj # <now can depend only on my_rel1_objs crutch, avoiding loading of rel2 objects, in case of a partial update>
    field :field_belongs_to_rel2_obj
end
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
