### PR TITLE
Use suffixed index names by default to prevent alias creation conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* [#973](https://github.com/toptal/chewy/pull/973): **(Potentially Breaking)** Indexes now use suffixed physical names from first creation (e.g., `users_1700000000000`) with an unsuffixed alias (`users`), instead of switching to this layout only after an index reset. This reduces the risk of a race condition during index reset. Existing unsuffixed indexes are not auto-migrated and continue to work, but direct ES operations that expect unsuffixed concrete index names may need updates. To migrate existing unsuffixed indexes to the alias-based layout, perform a one-time `chewy:reset` in a controlled window (pause jobs/writes that can recreate the unsuffixed index name). ([@dmeremyanin][])
+
 ## 8.1.0 (2026-05-28)
 
 ### New Features
@@ -865,6 +867,7 @@
 [@davekaro]: https://github.com/davekaro
 [@dck]: https://github.com/dck
 [@dm1try]: https://github.com/dm1try
+[@dmeremyanin]: https://github.com/dmeremyanin
 [@dmitry]: https://github.com/dmitry
 [@dnd]: https://github.com/dnd
 [@DNNX]: https://github.com/DNNX

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -197,6 +197,16 @@ module Chewy
         public_methods - Chewy::Index.public_methods
       end
 
+      # Generates suffix for index names. By default, the method
+      # returns a timestamp-based suffix, using the current time in milliseconds (e.g., 1638947285000).
+      #
+      # It is used to differentiate indexes for zero-downtime deployments.
+      #
+      # @return [Object] an object that can be cast to a string (e.g., integer, timestamp, etc.)
+      def timestamp_suffix
+        (Time.now.to_f * 1000).round
+      end
+
       def settings_hash
         _settings.to_hash
       end

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -7,12 +7,13 @@ module Chewy
       extend ActiveSupport::Concern
 
       module ClassMethods
-        # Checks index existance. Returns true or false
+        # Checks index existance. Supports suffixes. Returns true or false
         #
         #   UsersIndex.exists? #=> true
+        #   UsersIndex.exists?('11-2024') #=> false
         #
-        def exists?
-          client.indices.exists(index: index_name)
+        def exists?(suffix = nil)
+          client.indices.exists(index: index_name(suffix: suffix))
         end
 
         # Creates index and applies mappings and settings.

--- a/lib/chewy/index/import/routine.rb
+++ b/lib/chewy/index/import/routine.rb
@@ -68,7 +68,10 @@ module Chewy
           Chewy::Stash::Journal.create if @options[:journal] && !Chewy.configuration[:skip_journal_creation_on_import]
           return if Chewy.configuration[:skip_index_creation_on_import]
 
-          @index.create!(**@bulk_options.slice(:suffix)) unless @index.exists?
+          suffix = @bulk_options[:suffix] || @index.timestamp_suffix
+          index_exists = @bulk_options[:suffix] ? @index.exists?(suffix) : @index.exists?
+
+          @index.create!(suffix) unless index_exists
         end
 
         # The main process method. Converts passed objects to the bulk request body,

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -279,7 +279,7 @@ module Chewy
               next
             end
 
-            index.create!
+            index.create!(index.timestamp_suffix)
 
             output.puts "#{index.name} index successfully created"
           end
@@ -336,7 +336,9 @@ module Chewy
 
       def reset_one(index, output, parallel: false)
         output.puts "Resetting #{index}"
-        index.reset!((Time.now.to_f * 1000).round, parallel: parallel, apply_journal: journal_exists?)
+
+        suffix = index.timestamp_suffix
+        index.reset!(suffix, parallel: parallel, apply_journal: journal_exists?)
       end
 
       def warn_missing_index(output)

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -6,15 +6,20 @@ module Chewy
   #
   # @see Chewy::Index::Specification
   module Stash
-    class Specification < Chewy::Index
-      index_name 'chewy_specifications'
-
+    class Index < Chewy::Index
       default_import_options journal: false
+
+      # Disable automatic suffixes for specification and journal indexes
+      def self.timestamp_suffix; end
+    end
+
+    class Specification < Index
+      index_name 'chewy_specifications'
 
       field :specification, type: 'binary'
     end
 
-    class Journal < Chewy::Index
+    class Journal < Index
       index_name 'chewy_journal'
 
       # Loads all entries since the specified time.
@@ -54,8 +59,6 @@ module Chewy
 
         filter(terms: {index_name: indexes.map(&:derivable_name).uniq})
       end
-
-      default_import_options journal: false
 
       field :index_name, type: 'keyword'
       field :action, type: 'keyword'

--- a/spec/chewy/index/actions_spec.rb
+++ b/spec/chewy/index/actions_spec.rb
@@ -15,6 +15,18 @@ describe Chewy::Index::Actions do
       before { DummiesIndex.create }
       specify { expect(DummiesIndex.exists?).to eq(true) }
     end
+
+    context do
+      before { DummiesIndex.create('2024') }
+      specify { expect(DummiesIndex.exists?).to eq(true) }
+      specify { expect(DummiesIndex.exists?('2024')).to eq(true) }
+    end
+
+    context do
+      before { DummiesIndex.create('2024', alias: false) }
+      specify { expect(DummiesIndex.exists?).to eq(false) }
+      specify { expect(DummiesIndex.exists?('2024')).to eq(true) }
+    end
   end
 
   describe '.create' do

--- a/spec/chewy/index/import_spec.rb
+++ b/spec/chewy/index/import_spec.rb
@@ -32,11 +32,36 @@ describe Chewy::Index::Import do
 
   describe 'index creation on import' do
     let(:dummy_city) { City.create }
+    let(:dummy_timestamp_suffix) { (Time.now.to_f * 1000).round }
+
+    before do
+      allow(Chewy::Index).to receive(:timestamp_suffix).and_return(dummy_timestamp_suffix)
+    end
 
     specify 'lazy (default)' do
-      expect(CitiesIndex).to receive(:exists?).and_call_original
-      expect(CitiesIndex).to receive(:create!).and_call_original
+      expect(CitiesIndex).to receive(:exists?).with(no_args).and_call_original
+      expect(CitiesIndex).to receive(:create!).with(dummy_timestamp_suffix).and_call_original
       CitiesIndex.import(dummy_city)
+    end
+
+    specify 'lazy when index is already created' do
+      CitiesIndex.create!
+      expect(CitiesIndex).to receive(:exists?).with(no_args).and_call_original
+      expect(CitiesIndex).not_to receive(:create!)
+      CitiesIndex.import(dummy_city)
+    end
+
+    specify 'lazy when index is already created and suffix is given' do
+      CitiesIndex.create!(dummy_timestamp_suffix)
+      expect(CitiesIndex).to receive(:exists?).with(dummy_timestamp_suffix).and_call_original
+      expect(CitiesIndex).not_to receive(:create!)
+      CitiesIndex.import(dummy_city, suffix: dummy_timestamp_suffix)
+    end
+
+    specify 'lazy when suffix is given' do
+      expect(CitiesIndex).to receive(:exists?).with(dummy_timestamp_suffix).and_call_original
+      expect(CitiesIndex).to receive(:create!).with(dummy_timestamp_suffix).and_call_original
+      CitiesIndex.import(dummy_city, suffix: dummy_timestamp_suffix)
     end
 
     specify 'lazy without objects' do

--- a/spec/chewy/index_spec.rb
+++ b/spec/chewy/index_spec.rb
@@ -246,6 +246,16 @@ describe Chewy::Index do
     specify { expect(subject.specification).to equal(subject.specification) }
   end
 
+  describe '.timestamp_suffix' do
+    subject { stub_index(:documents) }
+
+    around do |spec|
+      Timecop.freeze { spec.run }
+    end
+
+    specify { expect(subject.timestamp_suffix).to eq((Time.now.to_f * 1000).round) }
+  end
+
   context 'index call inside index', :orm do
     before do
       stub_index(:cities) do

--- a/spec/chewy/search/request_spec.rb
+++ b/spec/chewy/search/request_spec.rb
@@ -755,12 +755,13 @@ describe Chewy::Search::Request do
         expect(subject.limit(5).source(:name).pluck(:id, :age)).to eq([[1, 10], [2, 20], [3, 30], [4, 40], [5, 50]])
       end
       specify do
+        index_name = ProductsIndex.indexes[0]
         expect(subject.limit(5).pluck(:_index, :name)).to eq([
-          %w[products Name1],
-          %w[products Name2],
-          %w[products Name3],
-          %w[products Name4],
-          %w[products Name5]
+          [index_name, 'Name1'],
+          [index_name, 'Name2'],
+          [index_name, 'Name3'],
+          [index_name, 'Name4'],
+          [index_name, 'Name5']
         ])
       end
 

--- a/spec/chewy/stash_spec.rb
+++ b/spec/chewy/stash_spec.rb
@@ -101,4 +101,8 @@ describe Chewy::Stash::Journal, :orm do
         .to contain_exactly('cities', 'countries', 'users')
     end
   end
+
+  describe '.timestamp_suffix' do
+    specify { expect(described_class.timestamp_suffix).to be_nil }
+  end
 end


### PR DESCRIPTION
## Synopsis

Recently, we encountered a problem during index reset operations where a race condition could cause an alias creation failure. The issue arises when:

1. An index (e.g., `users`) is being reset.
2. The reset task creates a new suffixed index (e.g., `users_<timestamp-suffix>`) and starts the import process.
3. Once the import is finished, the reset task deletes the old index ([here](https://github.com/toptal/chewy/blob/6a2176f7d92c4818f1a1f572aed339b39aef087e/lib/chewy/index/actions.rb#L166)).
4. The reset task attempts to create an alias (e.g., `users`) pointing to the new suffixed index ([here](https://github.com/toptal/chewy/blob/6a2176f7d92c4818f1a1f572aed339b39aef087e/lib/chewy/index/actions.rb#L167-L172)).
5. **The problem occurs**: There is a small time window between the old index deletion and the alias creation, during which another background job could recreate the unsuffixed `users` index. This results in a conflict when trying to create the alias, as both an index and an alias cannot share the same name.
6. **The result**: The alias creation fails, and no data is available in the index – the old index is deleted, and the new suffixed index is not aliased.

## Solution

To prevent this issue, I updated the index creation logic to always use suffixed index names and unsuffixed aliases by default, not just after an index reset. This ensures that the alias conflict issue caused by the recreation of the old unsuffixed index is avoided.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
