### PR TITLE
Excludes specs folder and other files when installing gem

### DIFF
--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = '~> 3.0'
 
-  spec.files         = `git ls-files`.split($RS)
+  spec.files         = Dir['CHANGELOG.md', 'LICENSE.txt', 'README.md', 'lib/**/*']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
This PR reduce significantly the number of directories/files created when installing the gem. Only the following are now installed:

- lib/**/*
- README.md
- LICENSE.txt
- CHANGELOG.md

I don't think its necessary to includes all the folders and files when installing the gem especially in production. Naturally, the gem will have a smaller footprint on a HD.