### PR TITLE
feat(add_replica_settings): Allow users to specify a replica endpoint…

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -101,6 +101,10 @@ module Chewy
       Chewy.current[:chewy_client] ||= Chewy::ElasticClient.new
     end
 
+    def client_replica
+      Chewy.current[:chewy_client_replica] ||= Chewy::ElasticClientReplica.new
+    end
+
     # Sends wait_for_status request to ElasticSearch with status
     # defined in configuration.
     #

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -130,6 +130,14 @@ module Chewy
       end
     end
 
+    def replica_configuration
+      yaml_settings.fetch(:replica, {}).merge(settings.dig(:replica).deep_symbolize_keys).tap do |configuration|
+        configuration[:logger] = transport_logger if transport_logger
+        configuration[:indices_path] ||= indices_path if indices_path
+        configuration.merge!(tracer: transport_tracer) if transport_tracer
+      end
+    end
+
   private
 
     def yaml_settings


### PR DESCRIPTION
… to allow syncing data to multiple clusters at once

Allow users to specify a `replica` key in settings and reference the replica in 3 main ways:

1) `client_replica` to make custom network requests via the ES client
2) `create_replica` + `create_replica!` to construct a fresh index
3) `delete_replica` + `delete_replica!` to delete the replica index

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
