### PR TITLE
feat(add_replica_settings): Allow switching between a primary and replica client for ES

### DIFF
--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -50,6 +50,7 @@ require 'chewy/fields/root'
 require 'chewy/journal'
 require 'chewy/railtie' if defined?(Rails::Railtie)
 require 'chewy/elastic_client'
+require 'chewy/elastic_client_replica'
 
 ActiveSupport.on_load(:active_record) do
   include Chewy::Index::Observe::ActiveRecordMethods
@@ -99,6 +100,14 @@ module Chewy
     #
     def client
       Chewy.current[:chewy_client] ||= Chewy::ElasticClient.new
+    end
+
+    def use_primary!
+      Chewy.current[:chewy_client] = Chewy::ElasticClient.new
+    end
+
+    def use_replica!
+      Chewy.current[:chewy_client] = Chewy::ElasticClientReplica.new
     end
 
     # Sends wait_for_status request to ElasticSearch with status

--- a/lib/chewy/config.rb
+++ b/lib/chewy/config.rb
@@ -123,7 +123,15 @@ module Chewy
     #            number_of_replicas: 0
     #
     def configuration
-      yaml_settings.merge(settings.deep_symbolize_keys).tap do |configuration|
+      yaml_settings.merge(settings.deep_symbolize_keys.except(:replica)).tap do |configuration|
+        configuration[:logger] = transport_logger if transport_logger
+        configuration[:indices_path] ||= indices_path if indices_path
+        configuration.merge!(tracer: transport_tracer) if transport_tracer
+      end
+    end
+
+    def replica_configuration
+      yaml_settings.fetch(:replica, {}).merge(settings.fetch(:replica, {}).deep_symbolize_keys).tap do |configuration|
         configuration[:logger] = transport_logger if transport_logger
         configuration[:indices_path] ||= indices_path if indices_path
         configuration.merge!(tracer: transport_tracer) if transport_tracer

--- a/lib/chewy/elastic_client_replica.rb
+++ b/lib/chewy/elastic_client_replica.rb
@@ -1,0 +1,31 @@
+module Chewy
+  # Replacement for Chewy.client
+  class ElasticClientReplica
+    def self.build_es_client(configuration = Chewy.replica_configuration)
+      client_configuration = configuration.deep_dup
+      client_configuration.delete(:prefix) # used by Chewy, not relevant to Elasticsearch::Client
+      block = client_configuration[:transport_options].try(:delete, :proc)
+      ::Elasticsearch::Client.new(client_configuration, &block)
+    end
+
+    def initialize(elastic_client = self.class.build_es_client)
+      @elastic_client = elastic_client
+    end
+
+  private
+
+    def method_missing(name, *args, **kwargs, &block)
+      inspect_payload(name, args, kwargs)
+
+      @elastic_client.__send__(name, *args, **kwargs, &block)
+    end
+
+    def respond_to_missing?(name, _include_private = false)
+      @elastic_client.respond_to?(name) || super
+    end
+
+    def inspect_payload(name, args, kwargs)
+      Chewy.config.before_es_request_filter&.call(name, args, kwargs)
+    end
+  end
+end


### PR DESCRIPTION
Allow switching between a primary and replica cluster to sync to multiple endpoints.

* Defaults Chewy.client to primary cluster
* Add `use_replica!` to override client to replica cluster
* Add `use_primary!` to override client to primary cluster

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
