### PR TITLE
Remove obsolete version attribute from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   elasticsearch_test:
     image: "elasticsearch:8.15.0"


### PR DESCRIPTION
Issues a deprecation warning when running docker compose currently

Background: https://docs.docker.com/reference/compose-file/version-and-name/