### PR TITLE
Add context option to .import for passing custom data  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### New Features
 
+* [#996](https://github.com/toptal/chewy/pull/996): Add `context:` option to `import`/`import!` for passing custom data to crutch blocks and field value procs without redundant DB queries.
+
 ### Changes
 * [#977](https://github.com/toptal/chewy/pull/977): Fewer files on gem installation [@ericproulx](https://github.com/ericproulx).
 

--- a/lib/chewy/fields/root.rb
+++ b/lib/chewy/fields/root.rb
@@ -61,8 +61,8 @@ module Chewy
       # @param fields [Array<Symbol>] a list of fields to compose, every field will be composed if empty
       # @return [Hash] JSON-ready hash with stringified keys
       #
-      def compose(object, crutches = nil, fields: [])
-        result = evaluate([object, crutches])
+      def compose(object, crutches = nil, fields: [], context: {})
+        result = evaluate([object, crutches, context])
 
         if children.present?
           child_fields = if fields.present?
@@ -72,7 +72,7 @@ module Chewy
           end
 
           child_fields.each_with_object({}) do |field, memo|
-            memo.merge!(field.compose(result, crutches) || {})
+            memo.merge!(field.compose(result, crutches, context) || {})
           end.as_json
         elsif fields.present?
           result.as_json(only: fields, root: false)

--- a/lib/chewy/index/crutch.rb
+++ b/lib/chewy/index/crutch.rb
@@ -9,9 +9,12 @@ module Chewy
       end
 
       class Crutches
-        def initialize(index, collection)
+        attr_reader :context
+
+        def initialize(index, collection, context = {})
           @index = index
           @collection = collection
+          @context = context
           @crutches_instances = {}
         end
 
@@ -26,7 +29,14 @@ module Chewy
         end
 
         def [](name)
-          @crutches_instances[name] ||= @index._crutches[:"#{name}"].call(@collection)
+          @crutches_instances[name] ||= begin
+            block = @index._crutches[:"#{name}"]
+            if block.arity > 1 || block.arity < -1
+              block.call(@collection, @context)
+            else
+              block.call(@collection)
+            end
+          end
         end
       end
 

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -115,13 +115,13 @@ module Chewy
         # @param crutches [Object] optional crutches object; if omitted - a crutch for the single passed object is created as a fallback
         # @param fields [Array<Symbol>] and array of fields to restrict the generated document
         # @return [Hash] a JSON-ready hash
-        def compose(object, crutches = nil, fields: [])
-          crutches ||= Chewy::Index::Crutch::Crutches.new self, [object]
+        def compose(object, crutches = nil, fields: [], context: {})
+          crutches ||= Chewy::Index::Crutch::Crutches.new self, [object], context
 
           if witchcraft? && root.children.present?
-            cauldron(fields: fields).brew(object, crutches)
+            cauldron(fields: fields).brew(object, crutches, context)
           else
-            root.compose(object, crutches, fields: fields)
+            root.compose(object, crutches, fields: fields, context: context)
           end
         end
 

--- a/lib/chewy/index/import/bulk_builder.rb
+++ b/lib/chewy/index/import/bulk_builder.rb
@@ -13,11 +13,12 @@ module Chewy
         # @param to_index [Array<Object>] objects to index
         # @param delete [Array<Object>] objects or ids to delete
         # @param fields [Array<Symbol, String>] and array of fields for documents update
-        def initialize(index, to_index: [], delete: [], fields: [])
+        def initialize(index, to_index: [], delete: [], fields: [], context: {})
           @index = index
           @to_index = to_index
           @delete = delete
           @fields = fields.map!(&:to_sym)
+          @context = context
         end
 
         # Returns ES API-ready bulk requiest body.
@@ -42,7 +43,7 @@ module Chewy
       private
 
         def crutches_for_index
-          @crutches_for_index ||= Chewy::Index::Crutch::Crutches.new @index, @to_index
+          @crutches_for_index ||= Chewy::Index::Crutch::Crutches.new @index, @to_index, @context
         end
 
         def index_entry(object)
@@ -257,7 +258,7 @@ module Chewy
         end
 
         def data_for(object, fields: [], crutches: crutches_for_index)
-          @index.compose(object, crutches, fields: fields)
+          @index.compose(object, crutches, fields: fields, context: @context)
         end
 
         def parent_changed?(data, old_parent)

--- a/lib/chewy/index/import/routine.rb
+++ b/lib/chewy/index/import/routine.rb
@@ -56,6 +56,7 @@ module Chewy
               {}
             end
           end
+          @context = @options.delete(:context) || {}
           @errors = []
           @stats = {}
           @leftovers = []
@@ -78,7 +79,7 @@ module Chewy
         # @param delete [Array<Object>] any acceptable objects for deleting
         # @return [true, false] the result of the request, true if no errors
         def process(index: [], delete: [])
-          bulk_builder = BulkBuilder.new(@index, to_index: index, delete: delete, fields: @options[:update_fields])
+          bulk_builder = BulkBuilder.new(@index, to_index: index, delete: delete, fields: @options[:update_fields], context: @context)
           bulk_body = bulk_builder.bulk_body
 
           if @options[:journal]

--- a/lib/chewy/index/witchcraft.rb
+++ b/lib/chewy/index/witchcraft.rb
@@ -59,15 +59,15 @@ module Chewy
           @fields = fields
         end
 
-        def brew(object, crutches = nil)
-          alicorn.call(locals, object, crutches).as_json
+        def brew(object, crutches = nil, context = {})
+          alicorn.call(locals, object, crutches, context).as_json
         end
 
       private
 
         def alicorn
           @alicorn ||= singleton_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            -> (locals, object0, crutches) do
+            -> (locals, object0, crutches, context) do
               #{composed_values(@index.root, 0)}
             end
           RUBY
@@ -189,6 +189,7 @@ module Chewy
               source = replace_lvar(source, proc_params[n], :"object#{n}") if proc_params[n]
             end
             source = replace_lvar(source, proc_params[nesting + 1], :crutches) if proc_params[nesting + 1]
+            source = replace_lvar(source, proc_params[nesting + 2], :context) if proc_params[nesting + 2]
 
             binding_variable_list(source).each do |variable|
               locals.push(proc.binding.eval(variable.to_s))

--- a/spec/chewy/index/witchcraft_spec.rb
+++ b/spec/chewy/index/witchcraft_spec.rb
@@ -84,6 +84,19 @@ describe Chewy::Index::Witchcraft do
       end
     end
 
+    context 'context' do
+      mapping do
+        field :name, value: ->(_o, _c, ctx) { ctx[:name] }
+      end
+
+      context do
+        let(:object) { double(name: 'Name') }
+        let(:crutches) { double }
+        let(:context) { {name: 'FromContext'} }
+        specify { expect(index.cauldron.brew(object, crutches, context)).to eq({name: 'FromContext'}.as_json) }
+      end
+    end
+
     context 'nesting' do
       context do
         mapping do


### PR DESCRIPTION
# Motivation

When importing objects, the data needed for indexing (e.g., embeddings, computed attributes) is often already available in memory at the call site. However, currently, crutch blocks are forced to re-fetch (even with direct_import) this data from the database, resulting in redundant queries and wasted resources.

There is currently no mechanism to pass this pre-computed data from the import call site down into crutch blocks or field value procs.

This design aligns with established patterns in the Ruby ecosystem, such as graphql-ruby and ActiveModelSerializers. In those libraries, a context object is similarly passed through the resolution or serialization stack to share request-level state (like current user, auth tokens, or pre-loaded data) without relying on global state.

# Solution

Add an optional `context:` keyword argument to `import`/`import!` that flows through the entire indexing pipeline. Context is an arbitrary hash, defaulting to `{}`.
```ruby
# Pass pre-computed data to avoid redundant DB queries
MyIndex.import!(objects, context: { embeddings: precomputed_embeddings })
```

## Context in crutch blocks (2nd argument)
```ruby
crutch :embeddings do |collection, context|
  # Use pre-computed data if available, otherwise fetch from DB
  context[:embeddings] || load_embeddings(collection)
end
```

## Context in field value procs (3rd argument)
```ruby
field :embedding, value: ->(object, crutches, context) {
  context[:override] || crutches.embeddings[object.id]
}
```

Both are fully backward-compatible — existing 1-arg crutch blocks and 1-2 arg field procs continue to work unchanged via arity-based dispatch.