### PR TITLE
[PF] Rubocop offenses are corrected, CHANGELOG entries are added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Changes
 
+* [#916](https://github.com/toptal/chewy/pull/916): Raise error in #scroll_batches when search backend returns a failure. ([@tomdev][])
+* [#1008](https://github.com/toptal/chewy/pull/1008): Promote Elasticsearch to a native GitHub Actions service with a health-check gate, replacing the fragile `docker compose` + `sleep 15` approach. ([@mattmenefee][])
 * [#1010](https://github.com/toptal/chewy/pull/1010): Add Chewy 7/ES 7 to Chewy 8/ES 8 migration guide and fix stale `Elasticsearch::Transport` namespace references in docs. ([@mattmenefee][])
 * [#1011](https://github.com/toptal/chewy/pull/1011): Replace deprecated `Sidekiq::Testing` API with new `Sidekiq 8.1+` testing API and silence Sidekiq logger during spec runs. ([@mattmenefee][], [@mjankowski][])
 * [#1013](https://github.com/toptal/chewy/pull/1013): Fix `drop_indices` test helper to use `format: 'json'` for ES version portability. If you define a custom `drop_indices` helper in your test suite, update it to use `Chewy.client.cat.indices(format: 'json')` instead of parsing the text-format response. ([@mattmenefee][])
 * [#1014](https://github.com/toptal/chewy/pull/1014): Improve contributing documentation with development setup instructions, PR workflow, and grammar fixes. ([@mattmenefee][])
-* [#1008](https://github.com/toptal/chewy/pull/1008): Promote Elasticsearch to a native GitHub Actions service with a health-check gate, replacing the fragile `docker compose` + `sleep 15` approach. ([@mattmenefee][])
 
 ## 8.0.1 (2026-03-12)
 
@@ -913,6 +914,7 @@
 [@socialchorus]: https://github.com/socialchorus
 [@taylor-au]: https://github.com/taylor-au
 [@TikiTDO]: https://github.com/TikiTDO
+[@tomdev]: https://github.com/tomdev
 [@undr]: https://github.com/undr
 [@Vitalina-Vakulchyk]: https://github.com/Vitalina-Vakulchyk
 [@webgago]: https://github.com/webgago

--- a/lib/chewy/errors.rb
+++ b/lib/chewy/errors.rb
@@ -39,7 +39,7 @@ module Chewy
 
   class MissingHitsInScrollError < Error
   end
-    
+
   class ImportScopeCleanupError < Error
   end
 

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -47,7 +47,7 @@ module Chewy
 
           yield(hits) if hits.present?
           scroll_id = result['_scroll_id']
-          
+
           break if result['terminated_early']
 
           result = perform_scroll(scroll: scroll, scroll_id: scroll_id) unless last_run


### PR DESCRIPTION
### Description

Two trailing-whitespace RuboCop offenses (`Layout/TrailingWhitespace`) are
corrected in `lib/chewy/errors.rb` and `lib/chewy/search/scrolling.rb`.

CHANGELOG is updated with entries for #916 (`#scroll_batches` error raising)
and #1008 (GitHub Actions service promotion), and the #1008 entry is moved
into chronological order. `@tomdev` is registered as a contributor.

### How to test

- Run `bundle exec rubocop lib/chewy/errors.rb lib/chewy/search/scrolling2.rb` and confirm no offenses
- Review CHANGELOG.md entries under the unreleased section for accuracy