### PR TITLE
Chewy::Stash::Journal.for uses a single terms filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#887](https://github.com/toptal/chewy/pull/887): Add support [runtime_mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html). ([@TakuyaKurimoto](https://github.com/TakuyaKurimoto))
 
+### Bug Fixes
+
+* [#878](https://github.com/toptal/chewy/issues/878): Flatten `Chewy::Stash::Journal.for` to use a single `terms` filter instead of a chain of `bool.should` clauses. Fixes Elasticsearch `indices.query.bool.max_nested_depth` errors when applying or cleaning the journal across many indices.
+
 ### Changes
 
 * [#916](https://github.com/toptal/chewy/pull/916): Raise error in #scroll_batches when search backend returns a failure. ([@tomdev][])

--- a/lib/chewy/stash.rb
+++ b/lib/chewy/stash.rb
@@ -38,17 +38,21 @@ module Chewy
 
       # Selects all the journal entries for the specified indices.
       #
+      # Uses a single `terms` filter rather than a chain of `bool.should`
+      # clauses so the query depth stays constant regardless of how many
+      # indices are passed. Avoids hitting the Elasticsearch
+      # `indices.query.bool.max_nested_depth` limit (default 30) when
+      # cleaning or applying journals across many indices.
+      #
       # @param indices [Chewy::Index, Array<Chewy::Index>]
       def self.for(*something)
         something = something.flatten.compact
-        indexes = something.flat_map { |s| Chewy.derive_name(s) }
-        return none if something.present? && indexes.blank?
+        return all if something.empty?
 
-        scope = all
-        indexes.each do |index|
-          scope = scope.or(filter(term: {index_name: index.derivable_name}))
-        end
-        scope
+        indexes = something.flat_map { |s| Chewy.derive_name(s) }
+        return none if indexes.blank?
+
+        filter(terms: {index_name: indexes.map(&:derivable_name).uniq})
       end
 
       default_import_options journal: false

--- a/spec/chewy/stash_spec.rb
+++ b/spec/chewy/stash_spec.rb
@@ -81,5 +81,24 @@ describe Chewy::Stash::Journal, :orm do
     specify do
       expect(described_class.for(CitiesIndex, UsersIndex).map(&:index_name)).to contain_exactly('cities', 'users')
     end
+
+    # Regression for #878: building the journal scope for many indices used to
+    # chain one `bool.should` clause per index, blowing past Elasticsearch's
+    # `indices.query.bool.max_nested_depth` (default 30). The new
+    # implementation collapses the clauses into a single `terms` filter.
+    specify 'renders a single terms filter regardless of index count' do
+      indexes = Array.new(100) { |i| stub_index(:"idx#{i}") }
+      index_names = indexes.map(&:derivable_name)
+
+      expect(described_class.for(indexes).render).to eq(
+        index: ['chewy_journal'],
+        body: {query: {bool: {filter: {terms: {index_name: index_names}}}}}
+      )
+    end
+
+    specify 'matches all entries when called with no indexes' do
+      expect(described_class.for([]).map(&:index_name))
+        .to contain_exactly('cities', 'countries', 'users')
+    end
   end
 end


### PR DESCRIPTION
Closes #878.

`Chewy::Stash::Journal.for` built the journal scope by chaining one `bool.should` clause per index, so query nesting grew linearly with the number of indices. Once it crossed Elasticsearch's `indices.query.bool.max_nested_depth` (default 30), `chewy:journal:clean` and `chewy:journal:apply` failed with `illegal_argument_exception` on any project with more than ~14 indices, and at higher counts the request body even tripped Yajl's 256-level encode cap before reaching ES. A single `terms` filter is semantically equivalent — match the journal entry's `index_name` against any of the given names — and keeps query depth constant regardless of how many indices are passed.

Edge cases are preserved: no indices returns `all`, all-unknown names return `none`, duplicates are deduped via `uniq`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

## Test plan

- `bundle exec rspec spec/chewy/stash_spec.rb` — includes a new regression test asserting `for(100 indexes).render` produces a single flat `terms` filter.
- `bundle exec rspec spec/chewy/journal_spec.rb spec/chewy/rake_helper_spec.rb spec/chewy/index/actions_spec.rb` — existing journal-touching suites stay green (217 examples).