### PR TITLE
Re-introduce import progressbar without GVL regression

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ plugins:
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
+  SuggestExtensions: false
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* Add `progressbar:` option to `import`/`import!` and a `PROGRESS=1` rake env toggle for `chewy:reset` / `chewy:update`. The bar is opt-in (default `false`), supports a `:unbounded` spinner mode that skips the `import_count` query, and is safe in parallel mode — workers stay process-based, the bar is incremented in the parent via `Parallel`'s `finish:` callback. Reintroduces the feature originally added in [#787](https://github.com/toptal/chewy/pull/787) and reverted in [#800](https://github.com/toptal/chewy/pull/800) without the GVL regression.
+
 ### Bug Fixes
 
 * Fix race condition during `reset!` where the unsuffixed concrete index could be recreated by a concurrent process between the delete and the alias creation, causing the alias creation to fail with an index/alias name collision.

--- a/docs/rake_tasks.md
+++ b/docs/rake_tasks.md
@@ -85,6 +85,20 @@ rake chewy:parallel:sync[4,-users]
 rake chewy:parallel:deploy[4] # performs parallel upgrade and parallel sync afterwards
 ```
 
+## Progress bar
+
+`chewy:reset` and `chewy:update` (including the parallel variants) can show an import progress bar on stderr.
+Set `PROGRESS=1` to enable it; set `PROGRESS=unbounded` to skip the upfront `count` query and show only the running count and elapsed time (no percentage, no total, no ETA).
+
+```bash
+PROGRESS=1 rake chewy:reset
+PROGRESS=unbounded rake chewy:parallel:reset[4]
+```
+
+Requires the optional `ruby-progressbar` gem (add `gem 'ruby-progressbar'` to your Gemfile). If absent, enabling `PROGRESS` raises a clear error; leaving it unset keeps imports silent.
+
+Parallel-safe: workers stay process-based; the bar is incremented in the parent process via the `Parallel` gem's `finish:` callback, so there is no GVL contention.
+
 ## `chewy:journal`
 
 This namespace contains two tasks for the journal manipulations: `chewy:journal:apply` and `chewy:journal:clean`. Both are taking time as the first argument (optional for clean) and a list of indexes exactly as the tasks above. Time can be in any format parsable by ActiveSupport.

--- a/lib/chewy.rb
+++ b/lib/chewy.rb
@@ -31,6 +31,7 @@ end
 try_require 'kaminari'
 try_require 'kaminari/core'
 try_require 'parallel'
+try_require 'ruby-progressbar'
 
 ActiveSupport.on_load(:active_record) do
   try_require 'kaminari/activerecord'

--- a/lib/chewy/index/actions.rb
+++ b/lib/chewy/index/actions.rb
@@ -174,7 +174,7 @@ module Chewy
             client.indices.update_aliases body: {actions: actions}
             client.indices.delete index: indexes if indexes.present?
 
-            self.journal.apply(start_time, **import_options) if apply_journal
+            self.journal.apply(start_time, **import_options.except(:progressbar)) if apply_journal
             result
           else
             purge!

--- a/lib/chewy/index/adapter/object.rb
+++ b/lib/chewy/index/adapter/object.rb
@@ -146,6 +146,23 @@ module Chewy
           collection.each_slice(options[:batch_size], &block)
         end
 
+        # Returns the count of objects that would be imported. Used by the
+        # progressbar feature to set the total. Mirrors {#import_args} input
+        # handling but does not enumerate batches.
+        #
+        # @return [Integer]
+        def import_count(*args)
+          args = args.dup
+          args.extract_options!
+          collection = if args.empty? && @target.respond_to?(import_all_method)
+            @target.send(import_all_method)
+          else
+            args.flatten(1).compact
+          end
+
+          collection.count
+        end
+
         # This method is used internally by the request DSL when the
         # collection of ORM/ODM objects is requested.
         #

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -96,6 +96,26 @@ module Chewy
         end
         alias_method :import_references, :import_fields
 
+        # Returns the count of records that would be imported. Used by the
+        # progressbar feature to set the total. Accepts the same shapes as
+        # {#import}: nothing (uses default scope), a relation, or an array
+        # of ids/objects.
+        #
+        # @return [Integer]
+        def import_count(*args)
+          args = args.dup
+          args.extract_options!
+          collection = if args.empty?
+            default_scope
+          elsif args.first.is_a?(relation_class)
+            args.first
+          else
+            args.flatten.compact
+          end
+
+          collection.count
+        end
+
         def load(ids, **options)
           scope = all_scope_where_ids_in(ids)
           additional_scope = options[options[:_index].to_sym].try(:[], :scope) || options[:scope]

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -2,6 +2,7 @@ require 'chewy/index/import/journal_builder'
 require 'chewy/index/import/bulk_builder'
 require 'chewy/index/import/bulk_request'
 require 'chewy/index/import/routine'
+require 'chewy/index/import/progressbar'
 
 module Chewy
   class Index
@@ -11,20 +12,22 @@ module Chewy
       IMPORT_WORKER = lambda do |index, options, total, ids, iteration|
         ::Process.setproctitle("chewy [#{index}]: import data (#{iteration + 1}/#{total})")
         routine = Routine.new(index, **options)
+        processed = 0
         index.adapter.import(*ids, routine.options) do |action_objects|
           routine.process(**action_objects)
+          processed += action_objects.sum { |_, v| v.size }
         end
-        {errors: routine.errors, import: routine.stats, leftovers: routine.leftovers}
+        {errors: routine.errors, import: routine.stats, leftovers: routine.leftovers, processed: processed}
       end
 
       LEFTOVERS_WORKER = lambda do |index, options, total, body, iteration|
         ::Process.setproctitle("chewy [#{index}]: import leftovers (#{iteration + 1}/#{total})")
         routine = Routine.new(index, **options)
         routine.perform_bulk(body)
-        routine.errors
+        {errors: routine.errors}
       end
 
-      module ClassMethods
+      module ClassMethods # rubocop:disable Metrics/ModuleLength
         # @!method import(*collection, **options)
         # Basically, one of the main methods for an index. Performs any objects import
         # to the index. Does all the objects handling routines.
@@ -71,6 +74,11 @@ module Chewy
         # @option options [Array<Symbol, String>] update_fields list of fields for the partial import, empty by default
         # @option options [true, false] update_failover enables full objects reimport in cases of partial update errors, `true` by default
         # @option options [true, Integer, Hash] parallel enables parallel import processing with the Parallel gem, accepts the number of workers or any Parallel gem acceptable options
+        # @option options [true, false, :unbounded] progressbar shows an import progressbar
+        #   on stderr. `true` precomputes the total via `adapter.import_count` (one extra
+        #   count query); `:unbounded` shows a spinner without computing the total. Default
+        #   `false`. Safe in parallel mode: the bar is incremented in the parent process via
+        #   `Parallel`'s `finish:` callback, workers stay process-based.
         # @return [true, false] false in case of errors
         def import(*args)
           intercept_import_using_strategy(*args).blank?
@@ -175,46 +183,91 @@ module Chewy
         end
 
         def import_linear(objects, routine)
+          bar = build_progressbar(routine, objects)
           ActiveSupport::Notifications.instrument 'import_objects.chewy', index: self do |payload|
             adapter.import(*objects, routine.options) do |action_objects|
               routine.process(**action_objects)
+              bar.increment(action_objects.sum { |_, v| v.size })
             end
             routine.perform_bulk(routine.leftovers)
             payload[:import] = routine.stats
             payload[:errors] = payload_errors(routine.errors) if routine.errors.present?
             payload[:errors]
           end
+        ensure
+          bar&.finish
         end
 
         def import_parallel(objects, routine)
           raise "The `parallel` gem is required for parallel import, please add `gem 'parallel'` to your Gemfile" unless '::Parallel'.safe_constantize
 
+          bar = build_progressbar(routine, objects)
           ActiveSupport::Notifications.instrument 'import_objects.chewy', index: self do |payload|
             batches = adapter.import_references(*objects, routine.options.slice(:batch_size)).to_a
 
             ::ActiveRecord::Base.connection.close if defined?(::ActiveRecord::Base)
             results = ::Parallel.map_with_index(
               batches,
-              routine.parallel_options,
+              parallel_options_with_progress(routine.parallel_options, bar),
               &IMPORT_WORKER.curry[self, routine.options, batches.size]
             )
             ::ActiveRecord::Base.connection.reconnect! if defined?(::ActiveRecord::Base)
             errors, import, leftovers = process_parallel_import_results(results)
-
-            if leftovers.present?
-              batches = leftovers.each_slice(routine.options[:batch_size])
-              results = ::Parallel.map_with_index(
-                batches,
-                routine.parallel_options,
-                &LEFTOVERS_WORKER.curry[self, routine.options, batches.size]
-              )
-              errors.concat(results.flatten(1))
-            end
+            errors.concat(process_parallel_leftovers(leftovers, routine)) if leftovers.present?
 
             payload[:import] = import
             payload[:errors] = payload_errors(errors) if errors.present?
             payload[:errors]
           end
+        ensure
+          bar&.finish
+        end
+
+        def process_parallel_leftovers(leftovers, routine)
+          batches = leftovers.each_slice(routine.options[:batch_size]).to_a
+          results = ::Parallel.map_with_index(
+            batches,
+            routine.parallel_options,
+            &LEFTOVERS_WORKER.curry[self, routine.options, batches.size]
+          )
+          results.flat_map { |r| r[:errors] }
+        end
+
+        # Builds Parallel options with a `finish:` callback that increments the
+        # progressbar after each worker batch returns. The callback runs in the
+        # parent (main) thread under Parallel's internal mutex (parallel-1.x),
+        # so workers stay process-based and there is no worker-side
+        # synchronization — the regression that triggered the PR #800 revert.
+        #
+        # If the caller already supplied a `finish:` callback in
+        # `parallel_options`, both run; user callback first, then the bar.
+        def parallel_options_with_progress(parallel_options, bar)
+          user_finish = parallel_options[:finish]
+          progress = lambda do |item, i, result|
+            user_finish&.call(item, i, result)
+            bar.increment(result[:processed]) if result.is_a?(Hash) && result[:processed]
+          end
+          parallel_options.merge(finish: progress)
+        end
+
+        def build_progressbar(routine, objects)
+          enabled = routine.options[:progressbar]
+          total = enabled == true ? safe_import_count(objects) : nil
+          Progressbar.build(enabled, total)
+        end
+
+        # Returns nil when the adapter cannot or should not be counted:
+        # missing `import_count` on a custom adapter, a grouped scope that
+        # raises, or any unexpected count failure. A nil total makes
+        # `Progressbar.new` render a spinner instead of a bounded bar —
+        # avoids aborting the import just because the progressbar can't
+        # size itself.
+        def safe_import_count(objects)
+          return nil unless adapter.respond_to?(:import_count)
+
+          adapter.import_count(*objects)
+        rescue StandardError
+          nil
         end
 
         def process_parallel_import_results(results)

--- a/lib/chewy/index/import/progressbar.rb
+++ b/lib/chewy/index/import/progressbar.rb
@@ -1,0 +1,79 @@
+module Chewy
+  class Index
+    module Import
+      # Thin wrapper around `ruby-progressbar` for import feedback.
+      #
+      # Unlike the original PR #787 implementation, this wrapper is only
+      # touched from the parent process: serial imports increment it directly,
+      # and parallel imports increment it via `Parallel`'s `finish:` callback
+      # (which runs in the parent under an internal mutex). The workers stay
+      # process-based, so there is no GVL contention as in PR #787 / #800.
+      #
+      # `Progressbar.build` returns a NULL object when the feature is disabled,
+      # so call sites do not need feature guards.
+      class Progressbar
+        NULL = Object.new
+        class << NULL
+          def increment(_); end
+          def total=(_); end
+          def finish; end
+        end
+
+        BOUNDED_FORMAT = '%t |%B| %p%% %c/%C %e'.freeze
+        UNBOUNDED_FORMAT = '%t %c (%a)'.freeze
+        TITLE = 'Importing'.freeze
+
+        # @param enabled [Boolean, :unbounded] feature flag. `:unbounded` shows
+        #   a spinner with no total (skip `import_count`).
+        # @param total [Integer, nil] expected total; ignored when `:unbounded`.
+        # @return [Progressbar, NULL]
+        def self.build(enabled, total)
+          return NULL unless enabled
+
+          unless '::ProgressBar'.safe_constantize
+            raise 'The `ruby-progressbar` gem is required for import progress, ' \
+                  "please add `gem 'ruby-progressbar'` to your Gemfile"
+          end
+
+          return new if enabled == :unbounded
+
+          new(normalize_total(total))
+        end
+
+        # Some ActiveRecord scopes (e.g., `.group(...)`) make `.count` return a
+        # Hash rather than an Integer. Coerce so we still get a usable total.
+        def self.normalize_total(total)
+          case total
+          when Hash then total.values.sum
+          when Integer then total
+          end
+        end
+
+        attr_reader :bar
+
+        def initialize(total = nil)
+          format = total ? BOUNDED_FORMAT : UNBOUNDED_FORMAT
+          @bar = ::ProgressBar.create(title: TITLE, total: total, format: format)
+        end
+
+        # Clamps to total when bounded — action_objects may include :delete
+        # entries (parent-child re-indexing, delete_if scope) that aren't
+        # counted by `adapter.import_count`, which would otherwise raise
+        # ProgressBar::InvalidProgressError.
+        def increment(by)
+          target = bar.progress + by
+          target = [bar.total, target].min if bar.total
+          bar.progress = target
+        end
+
+        def total=(value)
+          bar.total = value
+        end
+
+        def finish
+          bar.finish unless bar.finished?
+        end
+      end
+    end
+  end
+end

--- a/lib/chewy/rake_helper.rb
+++ b/lib/chewy/rake_helper.rb
@@ -21,6 +21,8 @@ module Chewy
 
     DELETE_BY_QUERY_OPTIONS = %w[WAIT_FOR_COMPLETION REQUESTS_PER_SECOND SCROLL_SIZE].freeze
     FALSE_VALUES = %w[0 f false off].freeze
+    TRUE_VALUES = %w[1 t true on yes].freeze
+    UNBOUNDED_VALUES = %w[unbounded].freeze
 
     class << self
       # Performs zero-downtime reindexing of all documents for the specified indexes
@@ -105,7 +107,7 @@ module Chewy
           indexes_from(only: only, except: except).each_with_object([]) do |index, updated_indexes|
             if index.exists?
               output.puts "Updating #{index}"
-              index.import(parallel: parallel)
+              index.import(parallel: parallel, progressbar: progressbar_option)
               updated_indexes.push(index)
             else
               output.puts "Skipping #{index}, it does not exists (use rake chewy:reset[#{index.derivable_name}] to create and update it)"
@@ -336,7 +338,22 @@ module Chewy
 
       def reset_one(index, output, parallel: false)
         output.puts "Resetting #{index}"
-        index.reset!((Time.now.to_f * 1000).round, parallel: parallel, apply_journal: journal_exists?)
+        index.reset!((Time.now.to_f * 1000).round, parallel: parallel, apply_journal: journal_exists?, progressbar: progressbar_option)
+      end
+
+      def progressbar_option
+        value = ENV.fetch('PROGRESS', nil)
+        return false if value.nil? || value.empty?
+
+        case value.downcase
+        when *FALSE_VALUES then false
+        when *UNBOUNDED_VALUES then :unbounded
+        when *TRUE_VALUES then true
+        else
+          warn "PROGRESS=#{value.inspect} not recognized; treating as enabled. " \
+               "Use #{TRUE_VALUES.join('/')}, #{UNBOUNDED_VALUES.join('/')}, or #{FALSE_VALUES.join('/')}."
+          true
+        end
       end
 
       def warn_missing_index(output)

--- a/spec/chewy/index/import/progressbar_spec.rb
+++ b/spec/chewy/index/import/progressbar_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'chewy/index/import/progressbar'
+
+describe Chewy::Index::Import::Progressbar do
+  before do
+    allow(ProgressBar).to receive(:create).and_wrap_original do |m, **opts|
+      m.call(**opts, output: StringIO.new)
+    end
+  end
+
+  describe '.build' do
+    it 'returns the NULL object when disabled' do
+      progressbar = described_class.build(false, 100)
+      expect(progressbar).to be(described_class::NULL)
+    end
+
+    it 'returns a real bar when enabled with a total' do
+      progressbar = described_class.build(true, 50)
+      expect(progressbar).to be_a(described_class)
+      expect(progressbar.bar.total).to eq(50)
+    end
+
+    it 'returns a spinner bar with nil total when :unbounded' do
+      progressbar = described_class.build(:unbounded, 999)
+      expect(progressbar).to be_a(described_class)
+      expect(progressbar.bar.total).to be_nil
+    end
+
+    it 'bounded format includes percentage' do
+      expect(described_class::BOUNDED_FORMAT).to include('%p')
+    end
+
+    it 'unbounded format omits percentage, total, and ETA' do
+      expect(described_class::UNBOUNDED_FORMAT).not_to include('%p')
+      expect(described_class::UNBOUNDED_FORMAT).not_to include('%C')
+      expect(described_class::UNBOUNDED_FORMAT).not_to include('%e')
+    end
+  end
+
+  describe 'NULL object' do
+    it 'is callable like a real bar without effect' do
+      null = described_class::NULL
+      expect { null.increment(10) }.not_to raise_error
+      expect { null.total = 5 }.not_to raise_error
+      expect { null.finish }.not_to raise_error
+    end
+  end
+
+  describe '#increment' do
+    it 'advances the underlying bar' do
+      progressbar = described_class.new(10)
+      progressbar.increment(3)
+      expect(progressbar.bar.progress).to eq(3)
+    end
+
+    it 'clamps to total when overshooting' do
+      progressbar = described_class.new(5)
+      progressbar.increment(10)
+      expect(progressbar.bar.progress).to eq(5)
+    end
+
+    it 'is unbounded when total is nil' do
+      progressbar = described_class.new(nil)
+      progressbar.increment(1_000_000)
+      expect(progressbar.bar.progress).to eq(1_000_000)
+    end
+  end
+
+  describe '.normalize_total' do
+    it 'sums Hash values (e.g., grouped AR count)' do
+      expect(described_class.normalize_total({a: 3, b: 7})).to eq(10)
+    end
+
+    it 'returns Integer untouched' do
+      expect(described_class.normalize_total(42)).to eq(42)
+    end
+
+    it 'returns nil for anything else' do
+      expect(described_class.normalize_total('weird')).to be_nil
+    end
+  end
+
+  describe '#finish' do
+    it 'is idempotent' do
+      progressbar = described_class.new(1)
+      progressbar.increment(1)
+      expect { 2.times { progressbar.finish } }.not_to raise_error
+      expect(progressbar.bar).to be_finished
+    end
+  end
+end

--- a/spec/chewy/rake_helper_spec.rb
+++ b/spec/chewy/rake_helper_spec.rb
@@ -655,4 +655,71 @@ Total: \\d+s\\Z
       expect(block_output).to eq('expected output')
     end
   end
+
+  describe 'PROGRESS env forwarding' do
+    def with_progress_env(value)
+      prev = ENV.fetch('PROGRESS', nil)
+      value.nil? ? ENV.delete('PROGRESS') : (ENV['PROGRESS'] = value)
+      yield
+    ensure
+      prev.nil? ? ENV.delete('PROGRESS') : (ENV['PROGRESS'] = prev)
+    end
+
+    shared_examples 'forwards PROGRESS as :progressbar kwarg' do |env_value, expected|
+      it "passes progressbar: #{expected.inspect} (PROGRESS=#{env_value.inspect})" do
+        captured = []
+        allow(target).to receive(target_method) do |*_args, **kwargs|
+          captured << kwargs
+          nil
+        end
+        with_progress_env(env_value) { invoke.call }
+        expect(captured).not_to be_empty
+        expect(captured).to all(include(progressbar: expected))
+      end
+    end
+
+    context 'via .reset' do
+      let(:target)        { CitiesIndex }
+      let(:target_method) { :reset! }
+      let(:invoke)        { -> { described_class.reset(only: [CitiesIndex], output: StringIO.new) } }
+
+      include_examples 'forwards PROGRESS as :progressbar kwarg', nil,         false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', '',          false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', '0',         false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'false',     false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'off',       false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', '1',         true
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'yes',       true
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'unbounded', :unbounded
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'UNBOUNDED', :unbounded
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'true',      true
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'on',        true
+
+      it 'warns and treats unknown values as enabled' do
+        captured = []
+        allow(CitiesIndex).to receive(:reset!) do |*_a, **kw|
+          captured << kw
+          nil
+        end
+        expect do
+          with_progress_env('bogus') do
+            described_class.reset(only: [CitiesIndex], output: StringIO.new)
+          end
+        end.to output(/PROGRESS="bogus" not recognized/).to_stderr
+        expect(captured).to all(include(progressbar: true))
+      end
+    end
+
+    context 'via .update' do
+      before { CitiesIndex.create! }
+
+      let(:target)        { CitiesIndex }
+      let(:target_method) { :import }
+      let(:invoke)        { -> { described_class.update(only: [CitiesIndex], output: StringIO.new) } }
+
+      include_examples 'forwards PROGRESS as :progressbar kwarg', nil,         false
+      include_examples 'forwards PROGRESS as :progressbar kwarg', '1',         true
+      include_examples 'forwards PROGRESS as :progressbar kwarg', 'unbounded', :unbounded
+    end
+  end
 end


### PR DESCRIPTION
Re-adds the import progress bar originally introduced in #787 to resolve #469, this time without the perf regression that caused #800 to revert it.
The original implementation switched parallel import from process-based to thread-based so workers could share a `Mutex`-guarded progress bar, which serialized CPU-bound work behind the GVL.
Here, workers stay process-based; each returns the number of records it processed and the parent increments the bar via `Parallel`'s `finish:` callback, which already runs in the main thread under an internal mutex.
No worker-side synchronization.

The feature is opt-in: `progressbar: true` on `import`/`import!`, or `PROGRESS=1` on `chewy:reset`/`chewy:update` (including the parallel variants).
`PROGRESS=unbounded` (or `progressbar: :unbounded`) skips the upfront `import_count` query and shows a spinner — useful when counting the source is too expensive.
`PROGRESS` parsing whitelists known values (`1/true/on/yes`, `unbounded`, `0/false/off`); unknown values still enable the bar but emit a warning so typos don't silently flip behavior.

The bar is clamped to total so parent-child re-indexing or `delete_if` scopes can't push it past 100%, grouped AR scopes (where `.count` returns a Hash) fall back to summed values, and a missing `import_count` on a custom adapter degrades to a spinner rather than raising.
`bar.finish` runs in an `ensure` so an ES error mid-import leaves the terminal clean.
The `:progressbar` option is stripped before `reset!` forwards options to `journal.apply`, so per-group journal imports don't each spawn their own bar.

`ruby-progressbar` is an optional runtime dependency: loaded via `try_require` at boot (same pattern as `parallel`), with a friendly error raised at `Progressbar.build` time if the gem is missing.

## Example output

`PROGRESS=1` (bounded — runs one upfront `count` query, shows percentage, current/total, and ETA):

```
$ PROGRESS=1 bundle exec rake chewy:reset
Resetting UsersIndex
Importing |==================            | 60% 600000/1000000 00:00:08
```

`PROGRESS=unbounded` (no count query, shows current count and elapsed time, no percentage, no total, no ETA):

```
$ PROGRESS=unbounded bundle exec rake chewy:parallel:reset[4]
Resetting UsersIndex
Importing 600000 (00:00:08)
```

`PROGRESS=0` (or unset) keeps the previous silent behavior — no bar, no count query.

## Checklist

- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). _Resolves #469; references #787 and #800._
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the changelog if the new code introduces user-observable changes.

## Testing

```bash
bundle exec rspec spec/chewy/index/import/progressbar_spec.rb spec/chewy/rake_helper_spec.rb spec/chewy/index/adapter
PROGRESS=1 bundle exec rake chewy:reset
PROGRESS=unbounded bundle exec rake chewy:parallel:reset[4]
```

The first command runs the new and adjacent specs; the PROGRESS env-forwarding suite (`describe 'PROGRESS env forwarding'`) covers the parser end-to-end through public `.reset`/`.update` methods rather than poking the private helper.
The two rake invocations exercise the serial and parallel paths; the latter confirms workers stay process-based (`pstree` / `ps` will show child chewy import procs, not threads).