### PR TITLE
update_fields: [] is treated as a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix race condition during `reset!` where the unsuffixed concrete index could be recreated by a concurrent process between the delete and the alias creation, causing the alias creation to fail with an index/alias name collision.
   The delete + alias-add are now performed in a single atomic `_aliases` cluster state update via the `remove_index` action.
   No public API or layout change.
+* [#992](https://github.com/toptal/chewy/issues/992): `import(update_fields: [])` is now a no-op (zero fields to update) instead of triggering a full document reindex. The default of `update_fields` is now `nil` (still performs a full reindex). Behavior change: any caller passing an explicit empty array previously got a silent full reimport; they will now skip the update.
 
 ### Changes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,13 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+
+  redis_test:
+    image: "redis:${REDIS_VERSION:-7}"
+    ports:
+      - "127.0.0.1:6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -71,7 +71,8 @@ module Chewy
         # @option options [Integer] batch_size passed to the adapter import method, used to split imported objects in chunks, 1000 by default
         # @option options [Boolean] direct_import skips object reloading in ORM adapter, `false` by default
         # @option options [true, false] journal enables imported objects journaling, false by default
-        # @option options [Array<Symbol, String>] update_fields list of fields for the partial import, empty by default
+        # @option options [Array<Symbol, String>] update_fields list of fields for partial import. `nil` (default) triggers full document reindex;
+        #   an empty array (`[]`) is an explicit no-op (no fields updated).
         # @option options [true, false] update_failover enables full objects reimport in cases of partial update errors, `true` by default
         # @option options [true, Integer, Hash] parallel enables parallel import processing with the Parallel gem, accepts the number of workers or any Parallel gem acceptable options
         # @option options [true, false, :unbounded] progressbar shows an import progressbar

--- a/lib/chewy/index/import/bulk_builder.rb
+++ b/lib/chewy/index/import/bulk_builder.rb
@@ -13,11 +13,11 @@ module Chewy
         # @param to_index [Array<Object>] objects to index
         # @param delete [Array<Object>] objects or ids to delete
         # @param fields [Array<Symbol, String>] and array of fields for documents update
-        def initialize(index, to_index: [], delete: [], fields: [], context: {})
+        def initialize(index, to_index: [], delete: [], fields: nil, context: {})
           @index = index
           @to_index = to_index
           @delete = delete
-          @fields = fields.map!(&:to_sym)
+          @fields = fields&.map(&:to_sym)
           @context = context
         end
 
@@ -55,6 +55,8 @@ module Chewy
           data = data_for(object) if parent.present?
           if parent.present? && parent_changed?(data, parent)
             reindex_entries(object, data) + reindex_descendants(object)
+          elsif @fields&.empty?
+            []
           elsif @fields.present?
             return [] unless entry[:_id]
 
@@ -264,7 +266,7 @@ module Chewy
         def parent_changed?(data, old_parent)
           return false unless old_parent
           return false unless join_field?
-          return false unless @fields.include?(join_field.to_sym)
+          return false unless @fields&.include?(join_field.to_sym)
           return false unless data.key?(join_field)
 
           # The join field value can be a hash, e.g.:

--- a/lib/chewy/index/import/bulk_builder.rb
+++ b/lib/chewy/index/import/bulk_builder.rb
@@ -47,6 +47,8 @@ module Chewy
         end
 
         def index_entry(object)
+          return [] if @fields&.empty?
+
           entry = {}
           entry[:_id] = index_object_ids[object] if index_object_ids[object]
           entry[:routing] = routing(object) if join_field?
@@ -55,8 +57,6 @@ module Chewy
           data = data_for(object) if parent.present?
           if parent.present? && parent_changed?(data, parent)
             reindex_entries(object, data) + reindex_descendants(object)
-          elsif @fields&.empty?
-            []
           elsif @fields.present?
             return [] unless entry[:_id]
 

--- a/lib/chewy/index/import/routine.rb
+++ b/lib/chewy/index/import/routine.rb
@@ -31,7 +31,7 @@ module Chewy
 
         DEFAULT_OPTIONS = {
           refresh: true,
-          update_fields: [],
+          update_fields: nil,
           update_failover: true,
           batch_size: Chewy::Index::Adapter::Base::BATCH_SIZE
         }.freeze

--- a/spec/chewy/index/import/bulk_builder_spec.rb
+++ b/spec/chewy/index/import/bulk_builder_spec.rb
@@ -23,7 +23,21 @@ describe Chewy::Index::Import::BulkBuilder do
   let(:index) { CitiesIndex }
   let(:to_index) { [] }
   let(:delete) { [] }
-  let(:fields) { [] }
+  let(:fields) { nil }
+
+  describe '#initialize' do
+    before do
+      stub_index(:cities) do
+        field :name
+      end
+    end
+
+    it 'does not mutate the caller-supplied fields array' do
+      fields = %w[name].freeze
+      expect { described_class.new(CitiesIndex, fields: fields) }.not_to raise_error
+      expect(fields).to eq(%w[name])
+    end
+  end
 
   describe '#bulk_body' do
     context 'simple bulk', :orm do
@@ -81,6 +95,15 @@ describe Chewy::Index::Import::BulkBuilder do
               {update: {_id: 2, data: {doc: {'name' => 'City18'}}}},
               {delete: {_id: 3}}
             ])
+          end
+
+          context 'empty fields array is a no-op for indexed objects' do
+            let(:fields) { [] }
+            specify do
+              expect(subject.bulk_body).to eq([
+                {delete: {_id: 3}}
+              ])
+            end
           end
         end
       end

--- a/spec/chewy/index/import/routine_spec.rb
+++ b/spec/chewy/index/import/routine_spec.rb
@@ -20,7 +20,7 @@ describe Chewy::Index::Import::Routine do
         journal: nil,
         refresh: true,
         update_failover: true,
-        update_fields: [],
+        update_fields: nil,
         batch_size: 1000
       )
     end
@@ -32,7 +32,7 @@ describe Chewy::Index::Import::Routine do
         journal: nil,
         refresh: false,
         update_failover: true,
-        update_fields: [],
+        update_fields: nil,
         bulk_size: 1_048_576,
         batch_size: 100
       )
@@ -45,7 +45,7 @@ describe Chewy::Index::Import::Routine do
           journal: true,
           refresh: true,
           update_failover: true,
-          update_fields: [],
+          update_fields: nil,
           batch_size: 1000
         )
       end

--- a/spec/chewy/index/import_spec.rb
+++ b/spec/chewy/index/import_spec.rb
@@ -234,6 +234,21 @@ describe Chewy::Index::Import do
         before { expect(Chewy.client).to receive(:bulk).once.and_call_original }
         specify { expect(import(dummy_cities, update_fields: [:name])).to eq(true) }
       end
+
+      context 'empty update_fields array is a no-op' do
+        let(:original) { dummy_cities.first }
+
+        specify 'does not overwrite existing document and skips the bulk request' do
+          original.update!(name: 'mutated_in_db')
+          original.name = 'transient_overwrite'
+
+          expect(Chewy.client).not_to receive(:bulk)
+          expect(import([original], update_fields: [])).to eq(true)
+
+          doc = CitiesIndex.all.detect { |c| c.id.to_s == original.id.to_s }
+          expect(doc.name).to eq('name0')
+        end
+      end
     end
 
     context 'fields integrational' do


### PR DESCRIPTION
Passing `update_fields: []` to `import`/`import!` previously fell through to a full document reindex because `[].present?` is false. The result is silent data loss for any caller that builds the field list dynamically and ends up with an empty array (the [issue #992](https://github.com/toptal/chewy/issues/992) reporter hit this with a `transient_attributes(group)` pipeline). The fix distinguishes `nil` (default, full reindex — unchanged behavior) from `[]` (explicit empty set, no-op). On parent-child join indexes the new `nil` default would have crashed `parent_changed?` via `nil.include?`, so that call site is now nil-safe; semantically it still matches the old `[]` behavior.

The `docker-compose.yml` change adds a `redis_test` service so `bundle exec rspec` works locally without `CannotConnectError` from the sidekiq/delayed_sidekiq specs. CI already provisions Redis via the GHA services block.

Fix #992.

## Testing

* `docker compose up -d`
* `bundle exec rspec` — 2303 examples, 0 failures.
* Repro (covered by the new integration spec): import a doc, mutate the source object, call `import!([obj], update_fields: [])` — on master the doc gets overwritten; on this branch it stays intact and no bulk request is issued.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with \`[Fix #issue-number]\` (if the related issue exists).
* [x] Feature branch is up-to-date with \`master\` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/