### PR TITLE
Replace deprecated ZRANGEBYSCORE in delayed_sidekiq worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix race condition during `reset!` where the unsuffixed concrete index could be recreated by a concurrent process between the delete and the alias creation, causing the alias creation to fail with an index/alias name collision.
   The delete + alias-add are now performed in a single atomic `_aliases` cluster state update via the `remove_index` action.
   No public API or layout change.
+* [#1024](https://github.com/toptal/chewy/pull/1024): Replace deprecated `ZRANGEBYSCORE` with `ZRANGE ... BYSCORE` in the `delayed_sidekiq` worker Lua script. `ZRANGEBYSCORE` has been deprecated in Redis since 6.2.0.
 
 ### Changes
 

--- a/lib/chewy/strategy/delayed_sidekiq/worker.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/worker.rb
@@ -13,7 +13,7 @@ module Chewy
           local timechunks_key = prefix .. ":" .. type .. ":timechunks"
 
           -- Get timechunk_keys with scores less than or equal to the specified score
-          local timechunk_keys = redis.call('zrangebyscore', timechunks_key, '-inf', score)
+          local timechunk_keys = redis.call('zrange', timechunks_key, '-inf', score, 'byscore')
 
           -- Get all members from the sets associated with the timechunk_keys
           local members = {}


### PR DESCRIPTION
Redis deprecated `ZRANGEBYSCORE` in 6.2.0 in favor of `ZRANGE ... BYSCORE`. The `delayed_sidekiq` worker's Lua script still calls the deprecated form. Behavior is identical for the inclusive `-inf`..score range used here, so this is a direct 1:1 swap with no semantic change.

The minimum Redis version is already 6.2+ (required by Sidekiq 7) and 7+ (required by Sidekiq 8, the version pinned in `Gemfile.lock`), so the new syntax is available everywhere this strategy can run. `ZREMRANGEBYSCORE` (line 33) is not deprecated and stays.

Refs #928.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. Not applicable — pure command-name swap with identical semantics; existing delayed_sidekiq specs cover the path.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. Not applicable — no user-observable change.

[1]: https://chris.beams.io/posts/git-commit/