### PR TITLE
import_count on multi-select relations is corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* Fix `import_count` on relations with multiple `.select(...)` clauses so the bounded progressbar is used instead of silently falling back to the unbounded spinner. Bare `.count` produced `SELECT COUNT(col1, col2, ...)` (invalid SQL); `count(:all)` is used for relations. ([#1026](https://github.com/toptal/chewy/pull/1026))
+
 ### Changes
 
 ## 8.2.0 (2026-05-29)

--- a/lib/chewy/index/adapter/orm.rb
+++ b/lib/chewy/index/adapter/orm.rb
@@ -113,7 +113,7 @@ module Chewy
             args.flatten.compact
           end
 
-          collection.count
+          collection.is_a?(relation_class) ? collection.count(:all) : collection.count
         end
 
         def load(ids, **options)

--- a/spec/chewy/index/adapter/active_record_spec.rb
+++ b/spec/chewy/index/adapter/active_record_spec.rb
@@ -478,6 +478,19 @@ describe Chewy::Index::Adapter::ActiveRecord, :active_record do
     end
   end
 
+  describe '#import_count' do
+    subject { described_class.new(City) }
+    let!(:cities) { Array.new(3) { |i| City.create!(rating: i) { |c| c.id = i + 1 } } }
+
+    context 'relation with multi-column select' do
+      specify do
+        scope = City.select(:id).select('rating AS r')
+        expect { subject.import_count(scope) }.not_to raise_error
+        expect(subject.import_count(scope)).to eq(3)
+      end
+    end
+  end
+
   describe '#import_fields' do
     subject { described_class.new(Country) }
     let!(:countries) { Array.new(3) { |i| Country.create!(rating: i) { |c| c.id = i + 1 } } }


### PR DESCRIPTION
When `chewy:reset` runs with `PROGRESS=1`, some indices fell back to the unbounded spinner instead of the bounded progressbar. The culprit was `adapter.import_count`: on a relation with multiple `.select(...)` clauses, Active Record turns `relation.count` into `SELECT COUNT(col1, col2, ...)` which is invalid SQL and raises `StatementInvalid`. The error is rescued in `safe_import_count`, which returns `nil` and forces the unbounded format. Calling `count(:all)` on relations bypasses `select_values` and always emits `SELECT COUNT(*)`, restoring the bounded bar. Array inputs still use plain `.count`.

Hit in practice on platform's `AutocompleteSkillsIndex`, whose scope chains six `.select(...)` calls.

## Test plan

- [ ] `bundle exec rspec spec/chewy/index/adapter/active_record_spec.rb` — new `#import_count` example covers the multi-select regression; full file stays green.