### PR TITLE
Remove obsolete _type field references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* [#1028](https://github.com/toptal/chewy/pull/1028): Remove the obsolete `_type` field from mock response helpers (`Chewy::Minitest::Helpers`, `Chewy::Rspec::Helpers`), `EVERFIELDS`, and `Chewy::Index::Wrapper` accessors. Elasticsearch removed `_type` from search responses in 8.0 (ES 7 already returned only the placeholder `_doc`), so these references no longer matched real responses. Also removes the long-obsolete `_parent` entry from `EVERFIELDS`. ([@mattmenefee][])
+
 ## 8.2.1 (2026-06-01)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ end
     },
     "_data":{
       "_index":"users",
-      "_type":"_doc",
       "_id":"1",
       "_score":0.9808291,
       "_source":{

--- a/lib/chewy/index/wrapper.rb
+++ b/lib/chewy/index/wrapper.rb
@@ -39,7 +39,7 @@ module Chewy
         end
       end
 
-      %w[_id _type _index].each do |name|
+      %w[_id _index].each do |name|
         define_method name do
           _data[name]
         end

--- a/lib/chewy/minitest/helpers.rb
+++ b/lib/chewy/minitest/helpers.rb
@@ -96,7 +96,6 @@ module Chewy
             'hits' => hits.each_with_index.map do |hit, i|
               {
                 '_index' => index.index_name,
-                '_type' => '_doc',
                 '_id' => hit[:id] || (i + 1).to_s,
                 '_score' => 3.14,
                 '_source' => hit

--- a/lib/chewy/rspec/helpers.rb
+++ b/lib/chewy/rspec/helpers.rb
@@ -39,7 +39,6 @@ module Chewy
             'hits' => hits.each_with_index.map do |hit, i|
               {
                 '_index' => index.index_name,
-                '_type' => '_doc',
                 '_id' => (i + 1).to_s,
                 '_score' => 3.14,
                 '_source' => hit

--- a/lib/chewy/search/request.rb
+++ b/lib/chewy/search/request.rb
@@ -18,7 +18,7 @@ module Chewy
       include Scoping
       include Scrolling
       UNDEFINED = Class.new.freeze
-      EVERFIELDS = %w[_index _type _id _parent _routing].freeze
+      EVERFIELDS = %w[_index _id _routing].freeze
       DELEGATED_METHODS = %i[
         query filter post_filter knn order reorder docvalue_fields
         track_scores track_total_hits request_cache explain version profile
@@ -952,7 +952,7 @@ module Chewy
 
       # Returns and array of values for specified fields.
       # Uses `source` to restrict the list of returned fields.
-      # Fields `_id`, `_type`, `_routing` and `_index` are also supported.
+      # Fields `_id`, `_routing` and `_index` are also supported.
       #
       # @overload pluck(field)
       #   If single field is passed - it returns and array of values.

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -25,6 +25,9 @@ In order to upgrade Chewy 7/Elasticsearch 7 to Chewy 8/Elasticsearch 8 in the mo
   * In test suites, consider switching to targeted index deletion instead of `Chewy.massacre`
 * Configure Elasticsearch 8 security:
   * ES 8 enables security features by default. Ensure your Chewy configuration includes proper authentication (username/password or API key) and SSL/TLS settings as needed.
+* Update test assertions for mock responses:
+  * If you use `mock_elasticsearch_response_sources` (in `Chewy::Minitest::Helpers` or `Chewy::Rspec::Helpers`), remove any assertions expecting `'_type' => '_doc'` in the mock hits it returns. The `_type` field has been removed from these helpers to match actual ES response format (ES 8 removed `_type` from search responses; ES 7 still returned the placeholder `'_doc'`).
+  * If you use `mock_elasticsearch_response` with a hand-crafted raw response hash, ensure your raw response does not include `'_type'` for consistency with ES 8+ responses.
 * Run your test suite on Chewy 8 / Elasticsearch 8
 * Run manual tests on Chewy 8 / Elasticsearch 8
 * Upgrade to Chewy 8

--- a/spec/chewy/minitest/helpers_spec.rb
+++ b/spec/chewy/minitest/helpers_spec.rb
@@ -31,7 +31,6 @@ describe :minitest_helper do
       [
         {
           '_index' => 'dummies',
-          '_type' => '_doc',
           '_id' => '2',
           '_score' => 3.14,
           '_source' => source

--- a/spec/chewy/rspec/helpers_spec.rb
+++ b/spec/chewy/rspec/helpers_spec.rb
@@ -13,7 +13,6 @@ describe :rspec_helper do
     [
       {
         '_index' => 'cities',
-        '_type' => '_doc',
         '_id' => '1',
         '_score' => 3.14,
         '_source' => source

--- a/spec/chewy/search/response_spec.rb
+++ b/spec/chewy/search/response_spec.rb
@@ -138,7 +138,6 @@ describe Chewy::Search::Response, :orm do
       let(:raw_response) do
         {'hits' => {'hits' => [
           {'_index' => 'cities',
-           '_type' => 'city',
            '_id' => '1',
            '_score' => 1.3,
            '_source' => {'id' => 2, 'rating' => 0}}
@@ -155,7 +154,6 @@ describe Chewy::Search::Response, :orm do
       let(:raw_response) do
         {'hits' => {'hits' => [
           {'_index' => 'countries',
-           '_type' => 'country',
            '_id' => '2',
            '_score' => 1.2,
            '_explanation' => {foo: 'bar'}}


### PR DESCRIPTION
## Summary

- Removes the obsolete `_type` field from Chewy. Elasticsearch removed `_type` from search responses in 8.0 (ES 7 already returned only the placeholder `_doc`), so these references no longer matched real ES responses.
- `_type` was still present in mock response helpers (`Chewy::Minitest::Helpers`, `Chewy::Rspec::Helpers`), so the fixtures they produced were misleading for anyone writing assertions against them.
- Also removed from `Chewy::Search::Request::EVERFIELDS` (along with the long-obsolete `_parent` entry), the `pluck` documentation, `Chewy::Index::Wrapper` generated accessors, and the README response example.
- Documents the mock-helper assertion change in the **Chewy 7 / ES 7 → Chewy 8 / ES 8** migration guide section (the upgrade where `_type` actually disappeared from responses).
- Behavioral no-op against ES 8+/9 clusters (none return `_type`); this only aligns the code and test fixtures with what Elasticsearch actually returns.

## Test plan

- [x] `bundle exec rspec spec/chewy/rspec/helpers_spec.rb spec/chewy/minitest/helpers_spec.rb spec/chewy/search/response_spec.rb spec/chewy/index/wrapper_spec.rb` (69 examples, 0 failures)
- [x] `bundle exec rspec spec/chewy/search/request_spec.rb -e pluck` (5 examples, 0 failures — exercises the `EVERFIELDS` path)
- [ ] CI green across the supported ES matrix
