### PR TITLE
Drop support for Ruby 3.2 and remove dead version guards

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
+        ruby: [ '3.3', '3.4', '4.0' ]
         gemfile: [rails.7.2.activerecord, rails.8.0.activerecord, rails.8.1.activerecord]
     name: ${{ matrix.ruby }}-${{ matrix.gemfile }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
 
 Layout/AccessModifierIndentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* [#1029](https://github.com/toptal/chewy/pull/1029): **(Breaking)** Drop support for Ruby 3.2, which reached end-of-life on 2026-04-01. Chewy now requires Ruby `>= 3.3`. ([@mattmenefee][])
+
 ## 8.4.1 (2026-06-19)
 
 ### New Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ do so.
 
 ### Prerequisites
 
-- Ruby 3.2+
+- Ruby 3.3+
 - Docker (for Elasticsearch)
 
 ### Starting Elasticsearch

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Chewy aims to support all Ruby and Rails versions that are currently maintained 
 
 ### Ruby
 
-Chewy is compatible with MRI 3.2-4.0.
+Chewy is compatible with MRI 3.3-4.0.
 
 ### Elasticsearch compatibility matrix
 

--- a/chewy.gemspec
+++ b/chewy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Chewy provides functionality for Elasticsearch index handling, documents import mappings and chainable query DSL'
   spec.homepage      = 'https://github.com/toptal/chewy'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.files         = Dir['CHANGELOG.md', 'LICENSE.txt', 'README.md', 'lib/**/*']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ See [configuration.md](configuration.md#import-scope-clean-up-behavior) for deta
 Some Chewy features require additional gems that are not listed as hard dependencies:
 
 - **`parallel`** — required for `chewy:parallel:*` rake tasks. Install it with `gem 'parallel'` in your Gemfile.
-- **`method_source`**, **`parser`** (or **`prism`** on Ruby 3.3+), **`unparser`** — required only for the deprecated `witchcraft!` path. Not needed for the default compiled compose path. Install them only if you still call `witchcraft!` from an index.
+- **`method_source`** and **`unparser`** — required only for the deprecated `witchcraft!` path. Not needed for the default compiled compose path. Install them only if you still call `witchcraft!` from an index.
 
 If these gems are missing you'll get a `LoadError` when the relevant feature is used.
 

--- a/lib/chewy/index/compiled.rb
+++ b/lib/chewy/index/compiled.rb
@@ -7,8 +7,7 @@ module Chewy
     # per-field arity into the call site and inlines hash construction,
     # removing the per-field iteration + dispatch overhead of the legacy
     # plain compose path. Proc bodies are NOT inlined — procs are called
-    # via `.call`. In exchange there are no parser/unparser/method_source
-    # deps and no Ruby/Prism version coupling.
+    # via `.call`.
     #
     # `fields:` selection is supported: a dedicated method is generated
     # and memoized per unique fields set.

--- a/lib/chewy/index/witchcraft.rb
+++ b/lib/chewy/index/witchcraft.rb
@@ -11,11 +11,7 @@ module Chewy
         return if @dependencies_loaded
 
         require 'method_source'
-        begin
-          require 'prism'
-        rescue LoadError
-          require 'parser/current'
-        end
+        require 'prism'
         require 'unparser'
         @dependencies_loaded = true
       rescue LoadError
@@ -38,11 +34,6 @@ module Chewy
         def check_requirements!
           messages = []
           messages << "MethodSource gem is required for the Witchcraft, please add `gem 'method_source'` to your Gemfile" unless Proc.method_defined?(:source)
-          if RUBY_VERSION >= '3.3'
-            messages << "Prism gem is required for the Witchcraft, please add `gem 'prism'` to your Gemfile" unless '::Prism'.safe_constantize
-          else
-            messages << "Parser gem is required for the Witchcraft, please add `gem 'parser'` to your Gemfile" unless '::Parser'.safe_constantize
-          end
           messages << "Unparser gem is required for the Witchcraft, please add `gem 'unparser'` to your Gemfile" unless '::Unparser'.safe_constantize
           messages = messages.join("\n")
 
@@ -211,11 +202,7 @@ module Chewy
         end
 
         def ast_from_proc(proc)
-          if defined?(Prism)
-            Prism::Translation::ParserCurrent.parse(proc.source)
-          else
-            Parser::CurrentRuby.parse(proc.source)
-          end
+          Prism::Translation::ParserCurrent.parse(proc.source)
         end
 
         def extract_lambdas(node)

--- a/lib/chewy/log_subscriber.rb
+++ b/lib/chewy/log_subscriber.rb
@@ -24,11 +24,7 @@ module Chewy
 
       subject = payload[:type].presence || payload[:index]
       action = "#{subject} #{action} (#{event.duration.round(1)}ms)"
-      action = if ActiveSupport.version >= Gem::Version.new('7.1')
-        color(action, GREEN, bold: true)
-      else
-        color(action, GREEN, true)
-      end
+      action = color(action, GREEN, bold: true)
 
       debug("  #{action} #{description}")
     end


### PR DESCRIPTION
## Summary

- **(Breaking)** Drops support for Ruby 3.2, which reached [end-of-life on 2026-04-01](https://www.ruby-lang.org/en/downloads/branches/) and no longer receives security patches.
- Raises the floor to **Ruby 3.3** (currently in security maintenance, EOL expected 2027-03-31):
  - `chewy.gemspec`: `required_ruby_version` `>= 3.2` → `>= 3.3`
  - `.github/workflows/ruby.yml`: drop `'3.2'` from the test matrix (3.3 was already covered)
  - `.rubocop.yml`: `TargetRubyVersion` `3.2` → `3.3`
  - README compatibility statement and CONTRIBUTING prerequisites
  - Troubleshooting guide: drop the `parser` / `prism` version conditional from the Witchcraft optional-dependency list, leaving `method_source` and `unparser` (Prism is bundled with Ruby 3.3+ and `parser` is pulled in transitively by `unparser`, so neither needs adding to a Gemfile)

### Dead version-guard cleanup (exposed by the floor bump)

- **`Chewy::Index::Witchcraft`** branched on `RUBY_VERSION >= '3.3'` to choose between **Prism** (a default gem since Ruby 3.3) and the external `parser` gem. The `parser` fallback in the `require` block, `check_requirements!`, and `ast_from_proc` is now unreachable, so witchcraft always uses Prism — also removing a fragile *string* version comparison. The Prism requirements check itself is dropped: Prism ships with Ruby 3.3+, so it's always present and never needs adding to a Gemfile; the real `parser` dependency is already covered transitively by the `unparser` check.
- **`Chewy::LogSubscriber`** branched on `ActiveSupport.version >= 7.1`, unconditionally true since the AS `>= 7.2` floor; the pre-7.1 positional `color` call is removed.

Version-anchored docs describing *past* releases' requirements (e.g. the Chewy 7 → 8 migration guide) are intentionally left unchanged.

## Test plan

- [x] `bundle exec rubocop` — no offenses with `TargetRubyVersion: 3.3`
- [x] `gem build chewy.gemspec` succeeds with `required_ruby_version >= 3.3`
- [ ] CI green on the Ruby 3.3 / 3.4 / 4.0 matrix
