### PR TITLE
Compiled compose path replaces witchcraft! as the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 _site
 .sass-cache
 file::memory:?cache=shared
+benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### New Features
 
+* New compiled compose path is now the default for every index. Chewy generates one `__chewy_compose__` method per index from the field tree on first import and reuses it for every object, replacing the iterative `Fields::Root#compose` loop. Typical document composition is 3-4× faster than the iterative path and matches `witchcraft!` performance without any extra dependencies. `update_fields:` partial imports are also covered via per-fields-set memoized methods.
+
 ### Bug Fixes
 
 ### Changes
+
+* **Deprecation:** `Chewy::Index.witchcraft!` is deprecated and will be removed in a future major release. It now prints a deprecation warning and is no longer required for fast composition — the compiled compose path described above is the default and delivers equivalent throughput without `method_source` / `parser` / `prism` / `unparser`. The `parser` / `prism` / `unparser` requires are now lazy and only loaded when an index actually calls `witchcraft!`, eliminating ~24 MiB of boot-time allocations and ~1 MiB of retained memory for apps that don't use it ([#644](https://github.com/toptal/chewy/issues/644)).
 
 * [#1028](https://github.com/toptal/chewy/pull/1028): Remove the obsolete `_type` field from mock response helpers (`Chewy::Minitest::Helpers`, `Chewy::Rspec::Helpers`), `EVERFIELDS`, and `Chewy::Index::Wrapper` accessors. Elasticsearch removed `_type` from search responses in 8.0 (ES 7 already returned only the placeholder `_doc`), so these references no longer matched real responses. Also removes the long-obsolete `_parent` entry from `EVERFIELDS`. ([@mattmenefee][])
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ end
 
 - [Getting Started](docs/getting_started.md) — end-to-end tutorial building search for a media library
 - [Configuration](docs/configuration.md) — client settings, update strategies, notifications, integrations
-- [Indexing](docs/indexing.md) — index definition, field types, crutches, witchcraft, index manipulation
+- [Indexing](docs/indexing.md) — index definition, field types, crutches, compiled compose path, index manipulation
 - [Import](docs/import.md) — import options, raw import, journaling
 - [Querying](docs/querying.md) — search requests, pagination, scopes, scroll, loading
 - [Rake Tasks](docs/rake_tasks.md) — all rake tasks and parallelization

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 ## Reference
 
 - [Configuration](configuration.md) — client settings, update strategies, notifications, integrations
-- [Indexing](indexing.md) — index definition, field types, crutches, witchcraft, index manipulation
+- [Indexing](indexing.md) — index definition, field types, crutches, compiled compose path, index manipulation
 - [Import](import.md) — import options, raw import, journaling
 - [Querying](querying.md) — search requests, pagination, scopes, scroll, loading
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -123,7 +123,7 @@ Key points:
 - The `author` object is denormalized into the book document — this is how
   you search across associations with Elasticsearch.
 
-See [indexing.md](indexing.md) for the full field DSL, crutches and witchcraft.
+See [indexing.md](indexing.md) for the full field DSL, crutches, and the compiled compose path.
 
 ## Connecting models
 
@@ -398,7 +398,7 @@ See [testing.md](testing.md) for the full RSpec/Minitest API including
 ## Next steps
 
 - [Configuration](configuration.md) — strategies, async workers, notifications
-- [Indexing](indexing.md) — full field DSL, crutches, witchcraft, geo points
+- [Indexing](indexing.md) — full field DSL, crutches, compiled compose path, geo points
 - [Import](import.md) — batching, raw import, journaling
 - [Querying](querying.md) — DSL details, pagination, scroll API, loading
 - [Rake Tasks](rake_tasks.md) — resetting, syncing, parallel execution

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -260,9 +260,33 @@ end
 
 So Chewy Crutches technology is able to increase your indexing performance in some cases up to a hundredfold or even more depending on your associations complexity. For another approach to import performance, see [Raw import](import.md#raw-import).
 
-## Witchcraft technology
+## Compiled compose path
 
-One more experimental technology to increase import performance. As far as you know, chewy defines value proc for every imported field in mapping, so at the import time each of these procs is executed on imported object to extract result document to import. It would be great for performance to use one huge whole-document-returning proc instead. So basically the idea or Witchcraft technology is to compile a single document-returning proc from the index definition.
+Every index automatically uses a compiled compose path: on the first import, Chewy generates one `__chewy_compose__` method per index from the field tree and calls it for every object instead of iterating through the field list at runtime.
+This typically gives **3-4× faster document composition** over the legacy iterative path with no code change required and no extra dependencies.
+
+The compiler:
+
+- Inlines the hash literal for the index document.
+- Bakes each field's accessor (method call, hash key lookup, or proc dispatch) directly into the generated source.
+- Calls value procs with exactly the arguments they declare (`(object)`, `(object, crutches)`, or `(object, crutches, context)`), so lambdas with optional arguments don't raise.
+- Supports `fields:` restriction by generating a separate cached method per unique fields set, so `update_fields:` partial imports stay on the fast path.
+
+There is nothing to opt into.
+The compiled path also handles hash inputs, join fields, and nested object fields the same way the legacy path did.
+
+For a small number of edge cases the compiler falls back to the legacy path automatically: `ignore_blank` fields, `geo_point` fields, indexes with a custom root value proc, and fields whose name is not a valid Ruby identifier.
+The fallback is transparent — the compose result is identical either way.
+
+## Witchcraft technology (deprecated)
+
+> **Deprecated**.
+> `witchcraft!` is retained only for compatibility with older index definitions and will be removed in a future major release.
+> The compiled compose path above is the default for all indexes and delivers equivalent performance without `method_source` / `parser` / `prism` / `unparser` dependencies, with substantially lower boot-time memory (see [#644](https://github.com/toptal/chewy/issues/644)).
+> Remove the `witchcraft!` call from your index — no other changes are needed.
+
+Witchcraft was an experimental performance optimization that used `method_source` to read each field value proc's Ruby source, parse it with `parser` or `prism`, rewrite the AST, and `Unparser`-emit a single fused lambda per index.
+Concretely it compiled definitions like this:
 
 ```ruby
 index_scope Product
@@ -276,7 +300,7 @@ field :categories do
 end
 ```
 
-The index definition above will be compiled to something close to:
+into a single lambda roughly equivalent to:
 
 ```ruby
 -> (object, crutches) do
@@ -285,7 +309,7 @@ The index definition above will be compiled to something close to:
     tags: object.tags.map(&:name),
     categories: object.categories.map do |object2|
       {
-        name: object2.name
+        name: object2.name,
         type: crutches.types[object2.name]
       }
     end
@@ -293,20 +317,15 @@ The index definition above will be compiled to something close to:
 end
 ```
 
-And don't even ask how is it possible, it is a witchcraft.
-Obviously not every type of definition might be compiled. There are some restrictions:
+It came with several limitations the compiled path does not have:
 
-1. Use reasonable formatting to make `method_source` be able to extract field value proc sources.
-2. Value procs with splat arguments are not supported right now.
-3. If you are generating fields dynamically use value proc with arguments, argumentless value procs are not supported yet:
+1. Required `method_source`-parseable proc source — reflowing a value proc could break the build.
+2. Did not support value procs with splat arguments.
+3. Required dynamically-generated fields to use procs with explicit arguments rather than argumentless `-> { ... }`.
+4. Required `method_source`, `parser` (or `prism`), and `unparser` at boot — together adding ~7 MiB of allocations and ~1 MiB of retained memory to every Rails boot, even for apps that did not call `witchcraft!`.
 
-  ```ruby
-  [:first_name, :last_name].each do |name|
-    field name, value: -> (o) { o.send(name) }
-  end
-  ```
-
-However, it is quite possible that your index definition will be supported by Witchcraft technology out of the box in most of the cases.
+Calling `witchcraft!` now prints a deprecation warning.
+Removing the call switches the index to the compiled path automatically; no other code changes are needed.
 
 ## Import context
 
@@ -336,7 +355,7 @@ field :embedding, value: ->(object, crutches, context) {
 
 Both are backward-compatible: existing 1-arg crutch blocks and 1-2 arg field procs continue to work unchanged via arity-based dispatch.
 
-Context is also supported under Witchcraft (`witchcraft!`) and under parallel imports (`parallel: N`).
+Context flows through the default compiled compose path automatically, and is also honored under the legacy `witchcraft!` path and under parallel imports (`parallel: N`).
 With `parallel:`, the same context hash is shared across all workers — precompute once on the main process, reuse in every worker.
 
 ```ruby

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ See [configuration.md](configuration.md#import-scope-clean-up-behavior) for deta
 Some Chewy features require additional gems that are not listed as hard dependencies:
 
 - **`parallel`** — required for `chewy:parallel:*` rake tasks. Install it with `gem 'parallel'` in your Gemfile.
-- **`method_source`** — required for the Witchcraft technology (compiled value procs). Install it with `gem 'method_source'`.
+- **`method_source`**, **`parser`** (or **`prism`** on Ruby 3.3+), **`unparser`** — required only for the deprecated `witchcraft!` path. Not needed for the default compiled compose path. Install them only if you still call `witchcraft!` from an index.
 
 If these gems are missing you'll get a `LoadError` when the relevant feature is used.
 

--- a/lib/chewy/fields/root.rb
+++ b/lib/chewy/fields/root.rb
@@ -3,10 +3,12 @@ module Chewy
     class Root < Chewy::Fields::Base
       attr_reader :dynamic_templates, :id
 
+      DEFAULT_VALUE = -> { self }
+
       def initialize(name, **options)
         super
 
-        @value ||= -> { self }
+        @value ||= DEFAULT_VALUE
         @dynamic_templates = []
       end
 

--- a/lib/chewy/index.rb
+++ b/lib/chewy/index.rb
@@ -11,6 +11,7 @@ require 'chewy/index/settings'
 require 'chewy/index/specification'
 require 'chewy/index/syncer'
 require 'chewy/index/witchcraft'
+require 'chewy/index/compiled'
 require 'chewy/index/wrapper'
 
 module Chewy
@@ -32,6 +33,7 @@ module Chewy
     include Observe
     include Crutch
     include Witchcraft
+    include Compiled
     include Wrapper
 
     singleton_class.delegate :client, to: 'Chewy'

--- a/lib/chewy/index/compiled.rb
+++ b/lib/chewy/index/compiled.rb
@@ -1,0 +1,238 @@
+module Chewy
+  class Index
+    # Compiled compose path. Default for all indexes.
+    #
+    # Generates a single `__chewy_compose__` method per index from the
+    # field tree (no Ruby source parsing of user procs). Bakes the
+    # per-field arity into the call site and inlines hash construction,
+    # removing the per-field iteration + dispatch overhead of the legacy
+    # plain compose path. Proc bodies are NOT inlined — procs are called
+    # via `.call`. In exchange there are no parser/unparser/method_source
+    # deps and no Ruby/Prism version coupling.
+    #
+    # `fields:` selection is supported: a dedicated method is generated
+    # and memoized per unique fields set.
+    #
+    # Falls back to the plain `Chewy::Fields::Root#compose` path when the
+    # field tree uses features the compiler does not handle:
+    # ignore_blank, geo_point, custom root value.
+    module Compiled
+      extend ActiveSupport::Concern
+
+      class UNSUPPORTED < StandardError
+      end
+
+      COMPILE_MUTEX = Mutex.new
+
+      module ClassMethods
+        # Returns true when this index can use the compiled path for the
+        # given compose call. Builds the per-fields method if needed.
+        def compiled_compose_available?(fields)
+          return false if witchcraft?
+          return false unless root&.children&.present?
+
+          ensure_compiled_compose_for!(fields)
+        rescue UNSUPPORTED
+          false
+        end
+
+        def compiled_compose(object, crutches, context, fields)
+          send(compiled_method_name(fields), object, crutches, context)
+        end
+
+        def compiled_procs
+          @compiled_procs ||= []
+        end
+
+        # Build (and cache) the compiled compose method for the given
+        # fields restriction. Returns true on success, false / raises on
+        # unsupported. Thread-safe: compilation under a process-wide
+        # mutex prevents two threads from interleaving appends into
+        # @compiled_procs and baking duplicate indices into class_eval'd
+        # method bodies.
+        def ensure_compiled_compose_for!(fields)
+          key = fields_key(fields)
+          built = (@compiled_compose_built ||= {})
+          return built[key] if built.key?(key)
+
+          COMPILE_MUTEX.synchronize do
+            return built[key] if built.key?(key)
+
+            method_name = compiled_method_name(fields)
+            source      = Compiler.new(self, fields: fields, method_name: method_name).build
+            class_eval(source, __FILE__, __LINE__)
+            built[key] = true
+          end
+        rescue UNSUPPORTED
+          (@compiled_compose_built ||= {})[fields_key(fields)] = false
+          raise
+        end
+
+        # Clears compiled-method cache and rebuilds-on-next-call. Hooked
+        # from `Mapping.field` so a `field` added after the first compose
+        # is picked up rather than absent from a stale generated method.
+        # Existing singleton methods remain defined (they shadow until
+        # rebuilt) but the cache flag is dropped so the next compose
+        # rebuilds and reassigns them.
+        def invalidate_compiled_compose!
+          @compiled_compose_built = nil
+          @compiled_procs = nil
+          @compiled_default_ready = false
+        end
+
+        def compiled_method_name(fields)
+          key = fields_key(fields)
+          return :__chewy_compose__ if key.empty?
+
+          :"__chewy_compose__#{key}"
+        end
+
+      private
+
+        # Distinct field sets are kept distinct by hashing the joined,
+        # sorted symbol names rather than joining with a separator that
+        # collides with `_` inside field names (e.g. [:full_name, :id]
+        # vs [:full, :name_id]). Hex-encoding the digest keeps the
+        # method name a valid Ruby identifier.
+        def fields_key(fields)
+          return ''.freeze if fields.nil? || fields.empty?
+
+          require 'digest'
+          Digest::SHA1.hexdigest(fields.map(&:to_sym).sort.join("\0"))[0, 12]
+        end
+
+      end
+
+      class Compiler
+        def initialize(index, fields: [], method_name: :__chewy_compose__)
+          @index       = index
+          @procs       = index.compiled_procs
+          @counter     = 0
+          @fields      = fields.map(&:to_sym)
+          @method_name = method_name
+        end
+
+        def build
+          check_root_value!(@index.root)
+          body = compose_children_src(@index.root, 'o0', restrict: @fields)
+          <<~RUBY
+            def self.#{@method_name}(o0, crutches, context)
+              #{body}.as_json
+            end
+          RUBY
+        end
+
+      private
+
+        def check_root_value!(root)
+          v = root.instance_variable_get(:@value)
+          return if v.equal?(Chewy::Fields::Root::DEFAULT_VALUE)
+
+          raise UNSUPPORTED, 'custom root value proc not supported by compiled path'
+        end
+
+        def compose_children_src(parent_field, obj_var, restrict: [])
+          children = parent_field.children
+          children = children.select { |f| restrict.include?(f.name) } if restrict.any?
+          # Plain Base#compose_children merges per-field hashes, so a field
+          # redeclared with the same name is silently last-wins. Match that
+          # here to avoid Ruby's "duplicate key" warning on the generated
+          # literal hash.
+          children = children.reverse.uniq(&:name).reverse
+
+          pairs = children.map do |f|
+            raise UNSUPPORTED, "field #{f.name}" if unsupported?(f)
+
+            # Use Ruby's literal-inspect for the key so names with quotes,
+            # backslashes, `#{}`, or other special characters are safely
+            # serialised — never raw-interpolated into source.
+            "#{f.name.to_s.inspect} => #{field_value_src(f, obj_var)}"
+          end
+          "{ #{pairs.join(', ')} }"
+        end
+
+        # Features the compiler refuses; caller falls back to plain.
+        # Join fields are supported via Field#value returning a proc.
+        def unsupported?(field)
+          return true if field.options.key?(:ignore_blank)
+          return true if field.options[:type].to_s == 'geo_point'
+
+          false
+        end
+
+        def field_value_src(field, parent_obj_var)
+          fetch = fetch_src(field, parent_obj_var)
+          return fetch if !field.children.present? || field.multi_field?
+
+          child_var = "o#{next_counter}"
+          raw_var   = "#{child_var}_raw"
+          children_src = compose_children_src(field, child_var)
+          <<~RUBY.chomp
+            (#{raw_var} = #{fetch}
+            if #{raw_var}.nil?
+              nil
+            elsif #{raw_var}.respond_to?(:to_ary)
+              #{raw_var}.to_ary.map { |#{child_var}| #{children_src} }
+            else
+              #{child_var} = #{raw_var}
+              #{children_src}
+            end)
+          RUBY
+        end
+
+        def fetch_src(field, obj_var)
+          v = field.value
+          if v.is_a?(Proc)
+            idx = @procs.size
+            @procs << v
+            procs_ref = "compiled_procs[#{idx}]"
+            param_count = positional_param_count(v)
+            case v.arity
+            when 0
+              "#{obj_var}.instance_exec(&#{procs_ref})"
+            else
+              # Pass only as many of (object, crutches, context) as the
+              # proc actually declares. This keeps lambdas with optional
+              # args (negative arity like `->(o, c=nil)`) from being
+              # called with too many arguments. Anything beyond context
+              # truncates to all three.
+              args = [obj_var, 'crutches', 'context'].first(param_count)
+              "#{procs_ref}.call(#{args.join(', ')})"
+            end
+          else
+            method_name = v.is_a?(Symbol) || v.is_a?(String) ? v.to_s : field.name.to_s
+            unless safe_identifier?(method_name)
+              raise UNSUPPORTED, "non-identifier field accessor: #{method_name.inspect}"
+            end
+
+            # Mirror Base#value_by_name_proc: hash key-or-string fallback,
+            # method send otherwise.
+            "(#{obj_var}.is_a?(Hash) ? " \
+              "(#{obj_var}.key?(:#{method_name}) ? #{obj_var}[:#{method_name}] : #{obj_var}['#{method_name}']) : " \
+              "#{obj_var}.#{method_name})"
+          end
+        end
+
+        # Number of positional parameters declared by `proc`, counting
+        # required + optional. Splats and keyword args contribute one
+        # bucket each so the caller still passes all three context args.
+        def positional_param_count(proc)
+          params = proc.parameters
+          required = params.count { |type, _| %i[req opt].include?(type) }
+          has_splat = params.any? { |type, _| type == :rest }
+          has_splat ? 3 : [required, 3].min
+        end
+
+        IDENTIFIER_RE = /\A[A-Za-z_][A-Za-z0-9_]*[!?=]?\z/
+
+        def safe_identifier?(name)
+          IDENTIFIER_RE.match?(name.to_s)
+        end
+
+        def next_counter
+          @counter += 1
+        end
+      end
+    end
+  end
+end

--- a/lib/chewy/index/compiled.rb
+++ b/lib/chewy/index/compiled.rb
@@ -100,10 +100,11 @@ module Chewy
           require 'digest'
           Digest::SHA1.hexdigest(fields.map(&:to_sym).sort.join("\0"))[0, 12]
         end
-
       end
 
       class Compiler
+        IDENTIFIER_RE = /\A[A-Za-z_][A-Za-z0-9_]*[!?=]?\z/
+
         def initialize(index, fields: [], method_name: :__chewy_compose__)
           @index       = index
           @procs       = index.compiled_procs
@@ -201,9 +202,7 @@ module Chewy
             end
           else
             method_name = v.is_a?(Symbol) || v.is_a?(String) ? v.to_s : field.name.to_s
-            unless safe_identifier?(method_name)
-              raise UNSUPPORTED, "non-identifier field accessor: #{method_name.inspect}"
-            end
+            raise UNSUPPORTED, "non-identifier field accessor: #{method_name.inspect}" unless safe_identifier?(method_name)
 
             # Mirror Base#value_by_name_proc: hash key-or-string fallback,
             # method send otherwise.
@@ -222,8 +221,6 @@ module Chewy
           has_splat = params.any? { |type, _| type == :rest }
           has_splat ? 3 : [required, 3].min
         end
-
-        IDENTIFIER_RE = /\A[A-Za-z_][A-Za-z0-9_]*[!?=]?\z/
 
         def safe_identifier?(name)
           IDENTIFIER_RE.match?(name.to_s)

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -127,7 +127,22 @@ module Chewy
         def compose(object, crutches = nil, fields: [], context: {})
           crutches ||= Chewy::Index::Crutch::Crutches.new self, [object], context
 
-          if witchcraft? && root.children.present?
+          # Hot path: the default-fields compiled method has already
+          # been built, so skip the per-call availability check and
+          # dispatch directly. Bulk reindexing hits this branch for
+          # every object after the first.
+          if fields.empty? && @compiled_default_ready
+            return __chewy_compose__(object, crutches, context)
+          end
+
+          if compiled_compose_available?(fields)
+            if fields.empty?
+              @compiled_default_ready = true
+              __chewy_compose__(object, crutches, context)
+            else
+              compiled_compose(object, crutches, context, fields)
+            end
+          elsif witchcraft? && root.children.present?
             cauldron(fields: fields).brew(object, crutches, context)
           else
             root.compose(object, crutches, fields: fields, context: context)

--- a/lib/chewy/index/import.rb
+++ b/lib/chewy/index/import.rb
@@ -131,9 +131,7 @@ module Chewy
           # been built, so skip the per-call availability check and
           # dispatch directly. Bulk reindexing hits this branch for
           # every object after the first.
-          if fields.empty? && @compiled_default_ready
-            return __chewy_compose__(object, crutches, context)
-          end
+          return __chewy_compose__(object, crutches, context) if fields.empty? && @compiled_default_ready
 
           if compiled_compose_available?(fields)
             if fields.empty?

--- a/lib/chewy/index/mapping.rb
+++ b/lib/chewy/index/mapping.rb
@@ -122,6 +122,7 @@ module Chewy
         #   end
         #
         def field(*args, **options, &block)
+          invalidate_compiled_compose! if respond_to?(:invalidate_compiled_compose!)
           if args.size > 1
             args.map { |name| field(name, **options) }
           else

--- a/lib/chewy/index/witchcraft.rb
+++ b/lib/chewy/index/witchcraft.rb
@@ -1,15 +1,3 @@
-begin
-  require 'method_source'
-  begin
-    require 'prism'
-  rescue LoadError
-    require 'parser/current'
-  end
-  require 'unparser'
-rescue LoadError
-  nil
-end
-
 module Chewy
   class Index
     module Witchcraft
@@ -19,8 +7,30 @@ module Chewy
         class_attribute :_witchcraft, instance_reader: false, instance_writer: false
       end
 
+      def self.load_dependencies!
+        return if @dependencies_loaded
+
+        require 'method_source'
+        begin
+          require 'prism'
+        rescue LoadError
+          require 'parser/current'
+        end
+        require 'unparser'
+        @dependencies_loaded = true
+      rescue LoadError
+        nil
+      end
+
       module ClassMethods
         def witchcraft!
+          warn(
+            '[DEPRECATION] Chewy::Index.witchcraft! is deprecated and will be removed in a future release. ' \
+            'The compiled compose path is now the default and delivers equivalent performance without ' \
+            "method_source/parser/unparser dependencies. Remove the `witchcraft!` call from #{name || self}.",
+            uplevel: 1
+          )
+          Witchcraft.load_dependencies!
           self._witchcraft = true
           check_requirements!
         end

--- a/spec/chewy/index/compiled_spec.rb
+++ b/spec/chewy/index/compiled_spec.rb
@@ -1,0 +1,209 @@
+require 'spec_helper'
+
+describe Chewy::Index::Compiled do
+  def self.mapping(&block)
+    before { stub_index(:products, &block) }
+  end
+
+  let(:index) { ProductsIndex }
+  let(:context) { {} }
+
+  describe 'compose (via compiled path)' do
+    context 'plain fields' do
+      mapping do
+        field :name
+        field :age
+        field :tags
+      end
+      let(:attrs) { {name: 'Name', age: 13, tags: %w[Ruby RoR]} }
+
+      it 'composes from method reads' do
+        expect(index.compose(double(attrs), context: context)).to eq(attrs.as_json)
+      end
+
+      it 'composes from hash keys (symbol)' do
+        expect(index.compose(attrs, context: context)).to eq(attrs.as_json)
+      end
+
+      it 'composes from hash keys (string)' do
+        expect(index.compose(attrs.stringify_keys, context: context)).to eq(attrs.as_json)
+      end
+    end
+
+    context 'value: lambdas of varying arity' do
+      mapping do
+        field :zero,  value: -> { name.upcase }
+        field :one,   value: ->(o) { o.age + 1 }
+        field :two,   value: ->(o, c) { c.bonus + o.age }
+        field :three, value: ->(o, _c, ctx) { ctx[:boost] * o.age }
+      end
+      let(:obj) { double(name: 'x', age: 10) }
+      let(:crutches) { double(bonus: 5) }
+      let(:context) { {boost: 3} }
+
+      it 'dispatches arity correctly' do
+        expect(index.compose(obj, crutches, context: context)).to eq(
+          'zero' => 'X', 'one' => 11, 'two' => 15, 'three' => 30
+        )
+      end
+    end
+
+    context 'value: symbol' do
+      mapping { field :display_name, value: :name }
+
+      it 'reads via method name' do
+        expect(index.compose(double(name: 'foo'))).to eq('display_name' => 'foo')
+      end
+    end
+
+    context 'nested object children' do
+      mapping do
+        field :addr do
+          field :city, value: ->(a) { a.city.upcase }
+        end
+      end
+
+      it 'handles single nested object' do
+        obj = double(addr: double(city: 'paris'))
+        expect(index.compose(obj)).to eq('addr' => {'city' => 'PARIS'})
+      end
+
+      it 'handles nil nested object' do
+        expect(index.compose(double(addr: nil))).to eq('addr' => nil)
+      end
+
+      it 'handles array of nested objects' do
+        obj = double(addr: [double(city: 'paris'), double(city: 'rome')])
+        expect(index.compose(obj)).to eq('addr' => [{'city' => 'PARIS'}, {'city' => 'ROME'}])
+      end
+    end
+
+    context 'fields: restriction' do
+      mapping do
+        field :name
+        field :age
+        field :extra, value: ->(o) { o.extra * 2 }
+      end
+
+      it 'composes only requested fields' do
+        obj = double(name: 'x', age: 1, extra: 5)
+        expect(index.compose(obj, fields: [:name])).to eq('name' => 'x')
+        expect(index.compose(obj, fields: %i[name extra])).to eq('name' => 'x', 'extra' => 10)
+      end
+
+      it 'reuses the same compiled method for the same fields set' do
+        obj = double(name: 'x', age: 1, extra: 5)
+        index.compose(obj, fields: %i[name extra])
+        first_methods = index.methods.grep(/__chewy_compose__/).size
+        5.times { index.compose(obj, fields: %i[extra name]) }
+        expect(index.methods.grep(/__chewy_compose__/).size).to eq(first_methods)
+      end
+    end
+
+    context 'duplicated field name' do
+      mapping do
+        field :full_name, value: ->(o) { "first-#{o.name}" }
+        field :full_name, value: ->(o) { "last-#{o.name}" }
+      end
+
+      it 'last declaration wins (no duplicate-key warning)' do
+        obj = double(name: 'x')
+        out = nil
+        expect { out = index.compose(obj) }.not_to output(/duplicated/).to_stderr
+        expect(out).to eq('full_name' => 'last-x')
+      end
+    end
+
+    context 'join field' do
+      mapping do
+        field :type_kind, type: 'join', relations: {parent: %i[child]},
+                          join: {type: :kind, id: :parent_id}
+      end
+
+      it 'composes join field as parent/child mapping' do
+        obj = double(kind: 'child', parent_id: 7)
+        expect(index.compose(obj)).to eq('type_kind' => {'name' => 'child', 'parent' => 7})
+      end
+    end
+
+    context 'lambda with default arguments (negative arity)' do
+      mapping do
+        field :a, value: ->(o, c = nil) { c ? c.boost + o.age : o.age }
+      end
+      let(:obj) { double(age: 7) }
+
+      it 'invokes lambda with only the args it declares' do
+        expect(index.compose(obj, double(boost: 5))).to eq('a' => 12)
+      end
+    end
+
+    context 'fields_key collision' do
+      mapping do
+        field :full_name, value: ->(o) { "FN:#{o.full_name}" }
+        field :id,        value: ->(o) { "ID:#{o.id}" }
+        field :full,      value: ->(o) { "F:#{o.full}" }
+        field :name_id,   value: ->(o) { "NI:#{o.name_id}" }
+      end
+
+      it 'does not confuse [:full_name, :id] with [:full, :name_id]' do
+        obj = double(full_name: 'X', id: 1, full: 'Y', name_id: 9)
+        expect(index.compose(obj, fields: %i[full_name id])).to eq('full_name' => 'FN:X', 'id' => 'ID:1')
+        expect(index.compose(obj, fields: %i[full name_id])).to eq('full' => 'F:Y', 'name_id' => 'NI:9')
+      end
+    end
+
+    context 'field added after first compose' do
+      mapping do
+        field :a, value: ->(o) { o.a }
+      end
+
+      it 'picks up newly defined field on subsequent compose' do
+        obj = double(a: 1, b: 2)
+        expect(index.compose(obj)).to eq('a' => 1)
+        index.field :b, value: ->(o) { o.b }
+        expect(index.compose(obj)).to eq('a' => 1, 'b' => 2)
+      end
+    end
+
+    context 'non-identifier field name' do
+      mapping do
+        field :'first-name', value: ->(o) { o.name }
+      end
+
+      it 'falls back to plain path rather than producing invalid Ruby source' do
+        obj = double(name: 'x')
+        expect(index.compose(obj)).to eq('first-name' => 'x')
+      end
+    end
+
+    context 'witchcraft fallback' do
+      mapping do
+        field :name
+      end
+
+      it 'uses witchcraft path when witchcraft! is set (with deprecation)' do
+        # silence the deprecation noise
+        original_stderr = $stderr
+        $stderr = StringIO.new
+        index.witchcraft!
+        $stderr = original_stderr
+        expect(index.compiled_compose_available?([])).to eq(false)
+      end
+    end
+  end
+
+  describe 'dispatch in Import.compose' do
+    mapping do
+      field :name
+      field :age, value: ->(o) { o.age * 2 }
+    end
+
+    it 'uses the compiled path by default' do
+      obj = double(name: 'a', age: 3)
+      # trigger lazy compile so the singleton method exists before we mock it
+      index.send(:ensure_compiled_compose_for!, [])
+      expect(index).to receive(:__chewy_compose__).and_call_original
+      expect(index.compose(obj)).to eq('name' => 'a', 'age' => 6)
+    end
+  end
+end

--- a/spec/chewy/index/compiled_spec.rb
+++ b/spec/chewy/index/compiled_spec.rb
@@ -154,20 +154,20 @@ describe Chewy::Index::Compiled do
 
     context 'field added after first compose' do
       mapping do
-        field :a, value: ->(o) { o.a }
+        field :a, value: ->(o) { o.a } # rubocop:disable Style/SymbolProc
       end
 
       it 'picks up newly defined field on subsequent compose' do
         obj = double(a: 1, b: 2)
         expect(index.compose(obj)).to eq('a' => 1)
-        index.field :b, value: ->(o) { o.b }
+        index.field :b, value: ->(o) { o.b } # rubocop:disable Style/SymbolProc
         expect(index.compose(obj)).to eq('a' => 1, 'b' => 2)
       end
     end
 
     context 'non-identifier field name' do
       mapping do
-        field :'first-name', value: ->(o) { o.name }
+        field :'first-name', value: ->(o) { o.name } # rubocop:disable Style/SymbolProc
       end
 
       it 'falls back to plain path rather than producing invalid Ruby source' do


### PR DESCRIPTION
`witchcraft!` made imports fast by reading each field's value proc source, parsing it, and emitting one fused lambda per index — but it was opt-in, fragile (depended on `method_source` reflowing proc source correctly), and dragged `parser`/`prism`/`unparser` into every Rails boot whether or not an index used it (~22 MiB of allocations, ~0.9 MiB retained per process, see #644). This replaces it with a compiler that builds the same single-method compose path straight from the field tree, so every index gets witchcraft-equivalent throughput by default with zero dependencies and nothing to opt into.

On the first import Chewy generates one `__chewy_compose__` method per index and reuses it for every object, replacing the iterative `Fields::Root#compose` loop. `update_fields:` partial imports stay on the fast path via a separate memoized method per unique fields set. A handful of cases the compiler can't express (`ignore_blank`, `geo_point`, custom root value procs, non-identifier field names) fall back to the legacy iterative path transparently, producing identical output.

`witchcraft!` is deprecated, not removed: it still works, but now prints a deprecation warning and loads its parser dependencies lazily, so apps that never call it pay no boot cost. Removing the call switches an index to the compiled path with no other change.

## Benchmarks

Measured locally on Ruby 4.0.4 with the scripts under `benchmark/` (CPU: 10k objects, median of 5 runs; memory via `memory_profiler`). The correctness harness confirms plain, witchcraft, and compiled produce byte-identical documents across all field tiers.

**Composition throughput** — speedup vs the iterative path:

| fields | iterative | witchcraft | compiled | compiled vs witch |
|-------:|----------:|-----------:|---------:|------------------:|
| 5      | 1.00×     | 4.98×      | 5.16×    | 1.04×             |
| 20     | 1.00×     | 4.26×      | 4.31×    | 1.01×             |
| 50     | 1.00×     | 4.30×      | 4.31×    | 1.00×             |

Compiled matches witchcraft within ~1% and is 4–5× faster than the iterative loop.

**Memory** — compiled vs witchcraft:

| measurement                    | compiled        | witchcraft       |
|--------------------------------|-----------------|------------------|
| boot + first compose, allocated | 0.49 MB         | 22.2 MB          |
| boot + first compose, retained  | ~0              | 0.93 MB          |
| steady-state per compose        | 2344 B / 11 obj | 3144 B / 16 obj  |

Dropping the parser stack from boot saves ~21.7 MB of allocations and ~0.9 MB retained per process for the common case. Compiled is also lighter per compose at steady state.

## Testing

- `bundle exec rspec spec/chewy/index/compiled_spec.rb` — covers compiled output parity, `fields:` restriction, proc-arity dispatch, and each fallback case.
- `bundle exec ruby benchmark/witchcraft_bench.rb` and `ruby benchmark/witchcraft_memory.rb` — reproduce the numbers above (the memory script needs the `memory_profiler` gem).
- Run an existing index import with and without `witchcraft!`; documents are identical and the deprecation warning fires only when `witchcraft!` is called.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/