### PR TITLE
delayed_sidekiq Array type error on Sidekiq 7+ is corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* ([#1034](https://github.com/toptal/chewy/issues/1034)): Fixed `delayed_sidekiq` strategy raising `TypeError: Unsupported command argument type: Array` on Sidekiq 7+. The LUA scripts now run via `EVALSHA` through a portable helper instead of redis-rb's keyword `eval`, which the redis-client-backed client Sidekiq 7+ yields does not support. ([@AlfonsoUceda][])
+
 ### Changes
 
 ## 8.3.0 (2026-06-05)

--- a/lib/chewy/strategy/delayed_sidekiq/redis_script.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/redis_script.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Chewy
+  class Strategy
+    class DelayedSidekiq
+      # Runs a LUA script through whatever client `Sidekiq.redis` yields.
+      #
+      # redis-rb (Sidekiq <= 6) accepts `eval(script, keys:, argv:)`, but the
+      # real Sidekiq 7+ runtime yields a redis-client-backed CompatClient that
+      # has no `#eval` and forwards the keyword args as a nested array, raising
+      # `TypeError: Unsupported command argument type: Array` (issue #971).
+      #
+      # `evalsha(sha, keys_array, argv_array)` is the one form both clients
+      # expand to the flat `EVALSHA sha numkeys *keys *argv` shape, so we load
+      # the script once and call it by digest, reloading on NOSCRIPT.
+      module RedisScript
+        def self.call(redis, script, keys:, argv:)
+          reloaded = false
+          begin
+            shas[script] ||= redis.script(:load, script)
+            redis.evalsha(shas[script], keys, argv)
+          rescue StandardError => e
+            raise if reloaded || !e.message.to_s.include?('NOSCRIPT')
+
+            reloaded = true
+            shas.delete(script) # flushed cache or failover: reload and retry once
+            retry
+          end
+        end
+
+        def self.shas
+          @shas ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/chewy/strategy/delayed_sidekiq/scheduler.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/scheduler.rb
@@ -10,6 +10,7 @@ require_relative '../../index'
 module Chewy
   class Strategy
     class DelayedSidekiq
+      require_relative 'redis_script'
       require_relative 'worker'
 
       LUA_SCRIPT = <<~LUA
@@ -98,7 +99,7 @@ module Chewy
         def postpone
           ::Sidekiq.redis do |redis|
             # do the redis stuff in a single command to avoid concurrency issues
-            if redis.eval(LUA_SCRIPT, keys: [timechunk_key, timechunks_key], argv: [serialize_data, at, ttl])
+            if RedisScript.call(redis, LUA_SCRIPT, keys: [timechunk_key, timechunks_key], argv: [serialize_data, at, ttl])
               ::Sidekiq::Client.push(
                 'queue' => sidekiq_queue,
                 'at' => at + margin,

--- a/lib/chewy/strategy/delayed_sidekiq/worker.rb
+++ b/lib/chewy/strategy/delayed_sidekiq/worker.rb
@@ -39,7 +39,7 @@ module Chewy
           options[:refresh] = !Chewy.disable_refresh_async if Chewy.disable_refresh_async
 
           ::Sidekiq.redis do |redis|
-            members = redis.eval(LUA_SCRIPT, keys: [], argv: [type, score, Scheduler::KEY_PREFIX])
+            members = RedisScript.call(redis, LUA_SCRIPT, keys: [], argv: [type, score, Scheduler::KEY_PREFIX])
 
             # extract ids and fields & do the reset of records
             ids, fields = extract_ids_and_fields(members)

--- a/spec/chewy/strategy/delayed_sidekiq/redis_script_spec.rb
+++ b/spec/chewy/strategy/delayed_sidekiq/redis_script_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+if defined?(Sidekiq)
+  describe Chewy::Strategy::DelayedSidekiq::RedisScript do
+    let(:script) { 'return { KEYS[1], ARGV[1] }' }
+
+    before { described_class.shas.clear }
+
+    describe '.call' do
+      context 'with real Sidekiq redis client' do
+        it 'evaluates the script with flat keys and argv' do
+          Sidekiq.redis do |redis|
+            result = described_class.call(redis, script, keys: ['k'], argv: ['v'])
+            expect(result).to eq(%w[k v])
+          end
+        end
+
+        it 'loads the script only once and reuses the cached digest' do
+          Sidekiq.redis do |redis|
+            expect(redis).to receive(:script).with(:load, script).once.and_call_original
+
+            2.times { described_class.call(redis, script, keys: ['k'], argv: ['v']) }
+          end
+        end
+      end
+
+      context 'error handling' do
+        let(:redis) { double('redis client') }
+
+        it 'reloads the digest and retries once on NOSCRIPT' do
+          allow(redis).to receive(:script).with(:load, script).and_return('sha1', 'sha2')
+          call_count = 0
+          allow(redis).to receive(:evalsha) do
+            call_count += 1
+            raise('NOSCRIPT No matching script') if call_count == 1
+
+            'ok'
+          end
+
+          expect(described_class.call(redis, script, keys: [], argv: [])).to eq('ok')
+          expect(redis).to have_received(:script).with(:load, script).twice
+        end
+
+        it 'gives up after a single retry when NOSCRIPT persists' do
+          allow(redis).to receive(:script).with(:load, script).and_return('sha1', 'sha2')
+          allow(redis).to receive(:evalsha).and_raise('NOSCRIPT No matching script')
+
+          expect { described_class.call(redis, script, keys: [], argv: []) }
+            .to raise_error(/NOSCRIPT/)
+          expect(redis).to have_received(:evalsha).twice
+        end
+
+        it 're-raises errors that are not NOSCRIPT' do
+          allow(redis).to receive(:script).with(:load, script).and_return('sha1')
+          allow(redis).to receive(:evalsha).and_raise(RuntimeError, 'WRONGTYPE')
+
+          expect { described_class.call(redis, script, keys: [], argv: []) }
+            .to raise_error(RuntimeError, 'WRONGTYPE')
+        end
+      end
+    end
+  end
+end

--- a/spec/chewy/strategy/delayed_sidekiq/scheduler_spec.rb
+++ b/spec/chewy/strategy/delayed_sidekiq/scheduler_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 if defined?(Sidekiq)
+  require 'redis'
+
   describe Chewy::Strategy::DelayedSidekiq::Scheduler do
     before do
       stub_model(:city)
@@ -72,6 +74,22 @@ if defined?(Sidekiq)
             expect(payload['at']).to eq(expected_at + margin)
           end
           described_class.new(CitiesIndex, [1]).postpone
+        end
+      end
+
+      context 'with real Sidekiq redis client' do
+        before do
+          allow(Sidekiq).to receive(:redis).and_call_original
+          Chewy::Strategy::DelayedSidekiq.clear_timechunks!
+        end
+
+        it 'schedules a Sidekiq job without raising' do
+          Timecop.freeze do
+            expect(Sidekiq::Client).to receive(:push).with(
+              hash_including('class' => Chewy::Strategy::DelayedSidekiq::Worker)
+            )
+            expect { described_class.new(CitiesIndex, [1, 2]).postpone }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/chewy/strategy/delayed_sidekiq/worker_spec.rb
+++ b/spec/chewy/strategy/delayed_sidekiq/worker_spec.rb
@@ -104,6 +104,25 @@ if defined?(Sidekiq)
           described_class.drain
         end
       end
+
+      context 'with real Sidekiq redis client' do
+        let(:city) { City.create!(name: 'London') }
+
+        before do
+          allow(Sidekiq).to receive(:redis).and_call_original
+          Sidekiq::Worker.clear_all
+          Chewy::Strategy::DelayedSidekiq.clear_timechunks!
+        end
+
+        it 'reindexes the scheduled ids without raising' do
+          Timecop.freeze do
+            Chewy::Strategy::DelayedSidekiq::Scheduler.new(CitiesIndex, [city.id]).postpone
+
+            expect(CitiesIndex).to receive(:import!).with([city.id.to_s])
+            expect { described_class.drain }.not_to raise_error
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Sidekiq 7+ yields a redis-client-backed client with no `#eval`; the keyword `eval(script, keys:, argv:)` form forwarded the keys array as a nested argument, which redis-client rejects. The scripts now run via EVALSHA through a shared helper, the one form both redis-rb and redis-client expand to flat arguments.
Fixes https://github.com/toptal/chewy/issues/971

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
