### PR TITLE
Scroll context for an empty result is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* [#1037](https://github.com/toptal/chewy/pull/1037): `#scroll_batches` now clears the scroll context opened for an empty result. The `_scroll_id` was only captured while iterating batches, so a zero-hit scope (which still opens a context on the initial request) leaked it until the scroll keepalive expired, contributing to `search.max_open_scroll_context` exhaustion.
+
 ### Changes
 
 ## 8.3.0 (2026-06-03)

--- a/lib/chewy/search/scrolling.rb
+++ b/lib/chewy/search/scrolling.rb
@@ -35,7 +35,7 @@ module Chewy
 
         total_batches += 1 if last_batch_size != 0
 
-        scroll_id = nil
+        scroll_id = result['_scroll_id']
 
         total_batches.times do |batch_counter|
           last_run = total_batches - 1 == batch_counter

--- a/spec/chewy/search/scrolling_spec.rb
+++ b/spec/chewy/search/scrolling_spec.rb
@@ -160,6 +160,11 @@ describe Chewy::Search::Scrolling, :orm do
         request.scroll_batches(batch_size: 3) {}
       end
 
+      it 'clears the scroll context opened for an empty result' do
+        expect(Chewy.client).to receive(:clear_scroll).with(body: {scroll_id: anything}).once.and_call_original
+        request.filter(term: {rating: -1}).scroll_batches(batch_size: 2) {}
+      end
+
       context 'instrumentation' do
         specify do
           outer_payload = []


### PR DESCRIPTION
`#scroll_batches` opens a scroll context on its initial request, then clears it in an `ensure` using a `scroll_id` it captures *inside* the per-batch loop. When the scope returns zero hits the loop body never runs, so `scroll_id` stays `nil`, the `ensure` skips `clear_scroll`, and the context Elasticsearch opened lingers until the scroll keepalive expires. Anything built on `scroll_batches` (`scroll_hits`, `scroll_objects`, and `pluck` on a limit-less scope) therefore leaks one context per empty-result call. Under load these pile up against the cluster-wide `search.max_open_scroll_context` limit (default 500), after which searches start failing with `too_many_scroll_contexts`.

The fix captures `_scroll_id` from the initial result before the loop, so the context is cleared no matter how many batches are iterated — including zero.

### How to test

Automated: `bundle exec rspec spec/chewy/search/scrolling_spec.rb` — includes a new example asserting `clear_scroll` is called for an empty result.

Manual, against a running ES:
```
curl -s 'localhost:9200/_nodes/stats/indices/search?filter_path=**.open_contexts'   # baseline
# run a scroll/pluck over a scope that matches no documents, e.g.
PlaceIndex.filter(term: {rating: -1}).scroll_batches(batch_size: 2) {}
curl -s 'localhost:9200/_nodes/stats/indices/search?filter_path=**.open_contexts'   # before: incremented and lingers; after: back to 0
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/