### PR TITLE
[OPS-3702] Add bundler cooldown of 7 days

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gem 'activerecord'
 

--- a/gemfiles/rails.7.2.activerecord.gemfile
+++ b/gemfiles/rails.7.2.activerecord.gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gem 'activejob', '~> 7.2.0'
 gem 'activerecord', '~> 7.2.0'

--- a/gemfiles/rails.8.0.activerecord.gemfile
+++ b/gemfiles/rails.8.0.activerecord.gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gem 'activejob', '~> 8.0.0'
 gem 'activerecord', '~> 8.0.0'

--- a/gemfiles/rails.8.1.activerecord.gemfile
+++ b/gemfiles/rails.8.1.activerecord.gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org', cooldown: 7
 
 gem 'activejob', '~> 8.1.0'
 gem 'activerecord', '~> 8.1.0'


### PR DESCRIPTION
[OPS-3702](https://toptal-core.atlassian.net/browse/OPS-3702)

Adds a bundler cooldown of 7 days to the `https://rubygems.org` source in the Gemfile. This delays installing gem versions published within the last 7 days, giving new releases time to be vetted by the community before they are pulled into this project, reducing exposure to malicious or broken releases that are typically caught and yanked shortly after publication.

Reference: https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/

[OPS-3702]: https://toptal-core.atlassian.net/browse/OPS-3702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ