### PR TITLE
[Fix #1042] Symbol#to_proc field values on the compiled compose path are corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+* Fixed `field ..., value: proc(&:method)` (and other splat-declaring procs) raising `ArgumentError: wrong number of arguments` during import. The compiled compose path introduced in 8.4.0 forwarded `crutches`/`context` as extra positional arguments to splat procs; `Symbol#to_proc` then passed them on to the method. Splat procs are now called with the object alone, matching the plain compose path. ([@AlfonsoUceda][])
+
 ### Changes
 
 ## 8.4.0 (2026-06-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@
 
 ### Bug Fixes
 
-* Fixed `field ..., value: proc(&:method)` (and other splat-declaring procs) raising `ArgumentError: wrong number of arguments` during import. The compiled compose path introduced in 8.4.0 forwarded `crutches`/`context` as extra positional arguments to splat procs; `Symbol#to_proc` then passed them on to the method. Splat procs are now called with the object alone, matching the plain compose path. ([@AlfonsoUceda][])
+### Changes
+
+## 8.4.1 (2026-06-19)
+
+### New Features
+
+### Bug Fixes
+
+* [#1043](https://github.com/toptal/chewy/pull/1043)Fixed `field ..., value: proc(&:method)` (and other splat-declaring procs) raising `ArgumentError: wrong number of arguments` during import. The compiled compose path introduced in 8.4.0 forwarded `crutches`/`context` as extra positional arguments to splat procs; `Symbol#to_proc` then passed them on to the method. Splat procs are now called with the object alone, matching the plain compose path. ([@AlfonsoUceda][])
 
 ### Changes
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -27,6 +27,7 @@
     field :email, analyzer: 'email' # Elasticsearch-related options
     field :country, value: ->(user) { user.country.name } # custom value proc
     field :badges, value: ->(user) { user.badges.map(&:name) } # passing array values to index
+    field :active, value: proc(&:active?) # Symbol#to_proc shorthand, same as ->(user) { user.active? }
     field :projects do # the same block syntax for multi_field, if `:type` is specified
       field :title
       field :description # default data type is `text`
@@ -269,7 +270,7 @@ The compiler:
 
 - Inlines the hash literal for the index document.
 - Bakes each field's accessor (method call, hash key lookup, or proc dispatch) directly into the generated source.
-- Calls value procs with exactly the arguments they declare (`(object)`, `(object, crutches)`, or `(object, crutches, context)`), so lambdas with optional arguments don't raise.
+- Calls value procs with exactly the arguments they declare (`(object)`, `(object, crutches)`, or `(object, crutches, context)`), so lambdas with optional arguments don't raise. Splat-declaring procs — including the `Symbol#to_proc` shorthand `value: proc(&:method)` — receive the object alone, so `value: proc(&:published?)` is equivalent to `value: ->(object) { object.published? }`.
 - Supports `fields:` restriction by generating a separate cached method per unique fields set, so `update_fields:` partial imports stay on the fast path.
 
 There is nothing to opt into.

--- a/lib/chewy/index/compiled.rb
+++ b/lib/chewy/index/compiled.rb
@@ -187,17 +187,24 @@ module Chewy
             idx = @procs.size
             @procs << v
             procs_ref = "compiled_procs[#{idx}]"
-            param_count = positional_param_count(v)
-            case v.arity
-            when 0
+            if v.arity.zero?
               "#{obj_var}.instance_exec(&#{procs_ref})"
+            elsif v.parameters.any? { |type, _| type == :rest }
+              # Procs that declare a splat — Symbol#to_proc (`proc(&:method)`,
+              # parameters `[[:req], [:rest]]`) and `->(*args)` — must NOT
+              # receive crutches/context as extra positional args: a symbol
+              # proc would forward them to the method (`obj.method(crutches,
+              # context)` => "wrong number of arguments"). Mirror the plain
+              # Base#value_by_proc negative-arity branch (`value.call(*object)`)
+              # so the compiled and fallback paths behave identically.
+              "#{procs_ref}.call(*#{obj_var})"
             else
               # Pass only as many of (object, crutches, context) as the
               # proc actually declares. This keeps lambdas with optional
               # args (negative arity like `->(o, c=nil)`) from being
               # called with too many arguments. Anything beyond context
               # truncates to all three.
-              args = [obj_var, 'crutches', 'context'].first(param_count)
+              args = [obj_var, 'crutches', 'context'].first(positional_param_count(v))
               "#{procs_ref}.call(#{args.join(', ')})"
             end
           else
@@ -212,14 +219,13 @@ module Chewy
           end
         end
 
-        # Number of positional parameters declared by `proc`, counting
-        # required + optional. Splats and keyword args contribute one
-        # bucket each so the caller still passes all three context args.
+        # Number of (object, crutches, context) args to pass to a splat-free
+        # proc: its required + optional positional parameters, capped at the
+        # three available. Splat procs are handled by the caller and never
+        # reach here.
         def positional_param_count(proc)
-          params = proc.parameters
-          required = params.count { |type, _| %i[req opt].include?(type) }
-          has_splat = params.any? { |type, _| type == :rest }
-          has_splat ? 3 : [required, 3].min
+          required = proc.parameters.count { |type, _| %i[req opt].include?(type) }
+          [required, 3].min
         end
 
         def safe_identifier?(name)

--- a/lib/chewy/version.rb
+++ b/lib/chewy/version.rb
@@ -1,3 +1,3 @@
 module Chewy
-  VERSION = '8.4.0'.freeze
+  VERSION = '8.4.1'.freeze
 end

--- a/spec/chewy/index/compiled_spec.rb
+++ b/spec/chewy/index/compiled_spec.rb
@@ -56,6 +56,23 @@ describe Chewy::Index::Compiled do
       end
     end
 
+    context 'value: Symbol#to_proc (proc(&:method))' do
+      mapping do
+        field :published, value: proc(&:published?)
+      end
+
+      let(:record) do
+        Class.new do
+          def published? = true
+        end.new
+      end
+
+      it 'invokes the proc with only the object, not crutches/context' do
+        expect(index.compose(record, double(boost: 1), context: {boost: 1}))
+          .to eq('published' => true)
+      end
+    end
+
     context 'nested object children' do
       mapping do
         field :addr do


### PR DESCRIPTION
Fixes #1042.

Indexing a field defined with the `Symbol#to_proc` shorthand (`value: proc(&:published?)`) raised `ArgumentError: wrong number of arguments (given 2, expected 0)` on 8.4.0, having worked on 8.0.1. The regression came from the compiled compose path introduced in 8.4.0: for any non-zero-arity proc it forwarded `(object, crutches, context)` as positional arguments. A `Symbol#to_proc` declares a splat, so it then passed `crutches` and `context` straight to the method (`object.published?(crutches, context)`). The legacy/fallback `Fields::Base#value_by_proc` never did this, which is why the plain path stayed correct.

The compiler now special-cases splat-declaring procs — `Symbol#to_proc` and `->(*args)` — and calls them with the object alone, matching the plain compose path exactly. Splat-free procs keep the existing `(object, crutches, context)` truncation, so optional-argument lambdas like `->(o, c = nil)` are unaffected.

## Testing

- `bundle exec rspec spec/chewy/index/compiled_spec.rb` — green, including the new `value: Symbol#to_proc` case. The test uses a real object rather than an RSpec double, since a double accepts any argument count and would mask the bug.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/