### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -60,8 +60,8 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1.319.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -72,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1.319.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: 3.4
           bundler-cache: true


### PR DESCRIPTION
Hi, small drive-by contribution: this pins the two actions in `ruby.yml` to their commit shas, with the versions kept as comments.

A tag like `@v7` or `@v1.319.0` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). With the sha, what runs is frozen to what you reviewed.

Dependabot keeps working exactly as today: it understands sha pins with a version comment and will keep opening its weekly bump PRs, same as #1049 did.

Both shas were resolved from the upstream repos and cross checked against their tags: checkout `3d3c42e` is v7.0.1, setup-ruby `003a5c4` is v1.319.0. No logic changes, only the four `uses:` lines.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on master. I can also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the changelog if the new code introduces user-observable changes. See [changelog entry format](https://github.com/toptal/chewy/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.

[1]: https://chris.beams.io/posts/git-commit/
